### PR TITLE
feat!: main/preload ごとの Vite 設定上書きを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Guide for AI coding agents working in this repository.
 
 A pnpm workspace monorepo containing a Vite 8 plugin (`@srymh/vite-plugin-electron`) that
 integrates Electron main/preload process builds using Vite's Environment API. The plugin
-source lives in `packages/vite-plugin-electron/`. Two example apps (`example-single/`,
-`example-multiple/`) demonstrate usage. Documentation, comments, and JSDoc are in Japanese.
+source lives in `packages/vite-plugin-electron/`. Example apps (`example-single/`, `example-multiple/`) demonstrate usage. Documentation, comments, and
+JSDoc are written in **Japanese**.
 
 ## Build / Lint / Test Commands
 

--- a/example-multiple/desktop/vite.config.ts
+++ b/example-multiple/desktop/vite.config.ts
@@ -6,8 +6,18 @@ import {
 } from '@srymh/vite-plugin-electron'
 
 const electronOptions: ElectronPluginOptions = {
-  main: 'src/main.ts',
-  preload: 'src/preload.ts',
+  main: {
+    entry: 'src/main.ts',
+    vite: {
+      build: { outDir: 'dist', sourcemap: true, minify: false },
+    },
+  },
+  preload: {
+    entry: 'src/preload.ts',
+    vite: {
+      build: { outDir: 'dist', sourcemap: true, minify: false },
+    },
+  },
   renderer: {
     mode: 'external',
     devUrl: 'http://localhost:5173',
@@ -16,11 +26,6 @@ const electronOptions: ElectronPluginOptions = {
     enabled: true,
     port: 9229,
     rendererPort: 9222,
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true,
-    minify: false,
   },
 }
 

--- a/example-single/vite.config.ts
+++ b/example-single/vite.config.ts
@@ -10,17 +10,22 @@ export default defineConfig(({ command }) => ({
   plugins: [
     react(),
     electron({
-      main: 'electron/main.ts',
-      preload: 'electron/preload.ts',
+      main: {
+        entry: 'electron/main.ts',
+        vite: {
+          build: { sourcemap: true, minify: false },
+        },
+      },
+      preload: {
+        entry: 'electron/preload.ts',
+        vite: {
+          build: { sourcemap: true, minify: false },
+        },
+      },
       debug: {
         enabled: true,
         port: 9229,
         rendererPort: 9222,
-      },
-      build: {
-        outDir: 'dist-electron',
-        sourcemap: true,
-        minify: false,
       },
     }),
     Inspect(),

--- a/packages/vite-plugin-electron/src/electron.ts
+++ b/packages/vite-plugin-electron/src/electron.ts
@@ -7,9 +7,9 @@ import { registerElectronDevServer } from './dev'
 import {
   EXTERNAL_RENDERER_CLIENT_ENTRY_ID,
   RESOLVED_EXTERNAL_RENDERER_CLIENT_ENTRY_ID,
-  createExternalRendererClientBuildConfig,
   createElectronEnvironmentBuildConfig,
   createElectronEnvironmentDefinitions,
+  createExternalRendererClientBuildConfig,
   removeExternalRendererClientBuildOutputs,
 } from './environment'
 import {

--- a/packages/vite-plugin-electron/src/electron.ts
+++ b/packages/vite-plugin-electron/src/electron.ts
@@ -23,11 +23,12 @@ import {
 } from './types'
 
 export type {
-  ElectronBuildOptions,
   ElectronDebugOptions,
+  ElectronMainOptions,
   ElectronPluginOptions,
   ElectronPreloadEntry,
   ElectronPreloadEntryMap,
+  ElectronPreloadInput,
   ElectronPreloadOptions,
   ElectronRendererMode,
   ElectronRendererOptions,
@@ -48,7 +49,7 @@ export type {
  * @param options plugin 利用者が指定する Electron 向け設定
  * @returns Vite plugin 定義
  */
-export function electron(options: ElectronPluginOptions = {}): Plugin {
+export function electron(options: ElectronPluginOptions): Plugin {
   const defaultRootDir = process.cwd()
   let resolvedOptions = resolveElectronPluginOptions(options, defaultRootDir)
 
@@ -93,7 +94,7 @@ export function electron(options: ElectronPluginOptions = {}): Plugin {
         server: {
           watch: {
             ignored: createOutDirIgnorePatterns(
-              currentOptions.outDir,
+              currentOptions,
               currentOptions.rootDir,
             ),
           },

--- a/packages/vite-plugin-electron/src/environment.ts
+++ b/packages/vite-plugin-electron/src/environment.ts
@@ -1,9 +1,8 @@
-import type { UserConfig } from 'vite'
+import { mergeConfig, type UserConfig } from 'vite'
 
 import {
   ELECTRON_MAIN_ENVIRONMENT_NAME,
   ELECTRON_PRELOAD_ENVIRONMENT_NAME,
-  MAIN_ENTRY_NAME,
   type ElectronEnvironmentName,
   type ElectronPreloadEntryMap,
   type ResolvedElectronPluginOptions,
@@ -52,8 +51,8 @@ export function createElectronEnvironmentDefinitions(
 /**
  * 指定された Electron environment 用の build 設定を組み立てる。
  *
- * main と preload では entry source と出力フォーマットが異なるため、environment 名に応じて
- * `rolldownOptions.input` と `output` を切り替える。
+ * まず plugin のベースデフォルトを構築し、ユーザーの vite override を Vite の
+ * `mergeConfig` で deep merge したあと、plugin が管理すべき不変の制約を再適用する。
  *
  * @param name build 設定を生成する environment 名
  * @param resolvedOptions 解決済み plugin オプション
@@ -63,40 +62,60 @@ export function createElectronEnvironmentBuildConfig(
   name: ElectronEnvironmentName,
   resolvedOptions: ResolvedElectronPluginOptions,
 ): UserConfig {
-  const { buildOptions, outDir, mainEntry, preloadEntries } = resolvedOptions
-  const shouldEmptyOutDir =
-    name === ELECTRON_MAIN_ENVIRONMENT_NAME
-      ? (buildOptions.emptyOutDir ?? true)
-      : false
+  const isMain = name === ELECTRON_MAIN_ENVIRONMENT_NAME
 
-  return {
+  const baseConfig: UserConfig = {
     build: {
-      outDir: outDir,
-      emptyOutDir: shouldEmptyOutDir,
-      copyPublicDir: buildOptions.copyPublicDir ?? false,
-      emitAssets: buildOptions.emitAssets ?? false,
-      minify: buildOptions.minify ?? false,
-      reportCompressedSize: buildOptions.reportCompressedSize ?? false,
-      sourcemap: buildOptions.sourcemap ?? true,
-      target: buildOptions.target ?? 'node22',
+      outDir: isMain
+        ? resolvedOptions.mainOutDir
+        : resolvedOptions.preloadOutDir,
+      emptyOutDir: isMain,
+      copyPublicDir: false,
+      emitAssets: false,
+      minify: false,
+      reportCompressedSize: false,
+      sourcemap: true,
+      target: 'node22',
       rolldownOptions: {
-        input:
-          name === ELECTRON_MAIN_ENVIRONMENT_NAME
-            ? { [MAIN_ENTRY_NAME]: mainEntry }
-            : preloadEntries,
-        external: [...new Set(['electron', ...(buildOptions.external ?? [])])],
+        external: ['electron'],
         output: {
-          entryFileNames:
-            name === ELECTRON_MAIN_ENVIRONMENT_NAME
-              ? '[name].js'
-              : '[name].cjs',
-          format: name === ELECTRON_MAIN_ENVIRONMENT_NAME ? 'es' : 'cjs',
-          chunkFileNames:
-            buildOptions.chunkFileNames ?? 'chunks/[name]-[hash].js',
+          entryFileNames: isMain ? '[name].js' : '[name].cjs',
+          format: isMain ? 'es' : 'cjs',
+          chunkFileNames: 'chunks/[name]-[hash].js',
         },
       },
     },
   }
+
+  const userOverrides = isMain
+    ? resolvedOptions.mainViteOverrides
+    : resolvedOptions.preloadViteOverrides
+
+  const merged = mergeConfig(baseConfig, userOverrides)
+
+  // --- 不変の制約を再適用 ---
+
+  // rolldownOptions.input は常に plugin が管理する。ユーザーの上書きは無視する。
+  merged.build.rolldownOptions.input = isMain
+    ? { [resolvedOptions.mainEntryName]: resolvedOptions.mainEntry }
+    : resolvedOptions.preloadEntries
+
+  // electron は常に外部化する。mergeConfig が配列を concat するため、
+  // ユーザーが external を指定した場合でも electron が含まれることは保証されるが、
+  // 念のため重複排除を行う。
+  const currentExternal = merged.build.rolldownOptions.external
+  if (Array.isArray(currentExternal)) {
+    merged.build.rolldownOptions.external = [
+      ...new Set(currentExternal as string[]),
+    ]
+  }
+
+  // preload は main が先にクリーンするため、常に emptyOutDir を無効にする。
+  if (!isMain) {
+    merged.build.emptyOutDir = false
+  }
+
+  return merged
 }
 
 /**

--- a/packages/vite-plugin-electron/src/index.ts
+++ b/packages/vite-plugin-electron/src/index.ts
@@ -1,11 +1,12 @@
 export { electron } from './electron'
 
 export type {
-  ElectronBuildOptions,
   ElectronDebugOptions,
+  ElectronMainOptions,
   ElectronPluginOptions,
   ElectronPreloadEntry,
   ElectronPreloadEntryMap,
+  ElectronPreloadInput,
   ElectronPreloadOptions,
   ElectronRendererMode,
   ElectronRendererOptions,

--- a/packages/vite-plugin-electron/src/options.ts
+++ b/packages/vite-plugin-electron/src/options.ts
@@ -65,10 +65,10 @@ export function resolveElectronPluginOptions(
 /**
  * ユーザーの vite override から実効 outDir を決定する。
  *
- * vite.build.outDir が指定されていればそれを、なければトップレベルの outDir を返す。
+ * vite.build.outDir が指定されていればそれを、なければデフォルトの outDir を返す。
  *
  * @param viteOverrides ユーザーが指定した vite 設定
- * @param defaultOutDir トップレベルの outDir
+ * @param defaultOutDir デフォルトの outDir
  * @returns 実効 outDir
  */
 function resolveEffectiveOutDir(

--- a/packages/vite-plugin-electron/src/options.ts
+++ b/packages/vite-plugin-electron/src/options.ts
@@ -3,12 +3,10 @@ import process from 'node:process'
 
 import {
   DEFAULT_RENDERER_DEV_SERVER_URL_ENV_VAR,
-  DEFAULT_MAIN_ENTRY,
   ELECTRON_OUT_DIR,
-  MAIN_ENTRY_NAME,
   type ElectronPluginOptions,
   type ElectronPreloadEntryMap,
-  type ElectronPreloadOptions,
+  type ElectronPreloadInput,
   type ResolvedElectronDebugOptions,
   type ResolvedElectronPluginOptions,
   type ResolvedElectronRendererOptions,
@@ -25,27 +23,81 @@ import {
  * @returns 内部利用向けに解決済みのオプション
  */
 export function resolveElectronPluginOptions(
-  options: ElectronPluginOptions = {},
+  options: ElectronPluginOptions,
   cwd: string = process.cwd(),
 ): ResolvedElectronPluginOptions {
-  const buildOptions = options.build ?? {}
-  const preloadEntries = Object.fromEntries(
-    Object.entries(normalizePreloadEntries(options.preload)).map(
-      ([name, source]) => [name, resolve(cwd, source)],
-    ),
+  const preloadEntries = options.preload
+    ? Object.fromEntries(
+        Object.entries(normalizePreloadEntries(options.preload.entry)).map(
+          ([name, source]) => [name, resolve(cwd, source)],
+        ),
+      )
+    : {}
+
+  const outDir = ELECTRON_OUT_DIR
+  const mainOutDir = resolveEffectiveOutDir(options.main.vite, outDir)
+  const preloadOutDir = resolveEffectiveOutDir(options.preload?.vite, outDir)
+  const mainEntryName = inferEntryName(options.main.entry)
+  const mainEntryFileNames = resolveEffectiveMainEntryFileNames(
+    options.main.vite,
   )
-  const outDir = buildOptions.outDir ?? ELECTRON_OUT_DIR
 
   return {
     rootDir: cwd,
-    mainEntry: resolve(cwd, options.main ?? DEFAULT_MAIN_ENTRY),
+    mainEntry: resolve(cwd, options.main.entry),
+    mainEntryName,
+    mainViteOverrides: options.main.vite ?? {},
     preloadEntries,
-    buildOptions,
+    preloadViteOverrides: options.preload?.vite ?? {},
     debugOptions: resolveDebugOptions(options.debug),
     rendererOptions: resolveRendererOptions(options.renderer),
     outDir,
-    mainOutputPath: resolve(cwd, outDir, `${MAIN_ENTRY_NAME}.js`),
+    mainOutDir,
+    preloadOutDir,
+    mainOutputPath: resolve(
+      cwd,
+      mainOutDir,
+      mainEntryFileNames.replace('[name]', mainEntryName),
+    ),
   }
+}
+
+/**
+ * ユーザーの vite override から実効 outDir を決定する。
+ *
+ * vite.build.outDir が指定されていればそれを、なければトップレベルの outDir を返す。
+ *
+ * @param viteOverrides ユーザーが指定した vite 設定
+ * @param defaultOutDir トップレベルの outDir
+ * @returns 実効 outDir
+ */
+function resolveEffectiveOutDir(
+  viteOverrides: ElectronPluginOptions['main']['vite'],
+  defaultOutDir: string,
+): string {
+  return viteOverrides?.build?.outDir ?? defaultOutDir
+}
+
+/**
+ * ユーザーの vite override から main 用 entryFileNames を決定する。
+ *
+ * rolldownOptions.output.entryFileNames が指定されていればそれを、
+ * なければ既定の '[name].js' を返す。
+ *
+ * @param viteOverrides ユーザーが指定した vite 設定
+ * @returns 実効 entryFileNames
+ */
+function resolveEffectiveMainEntryFileNames(
+  viteOverrides: ElectronPluginOptions['main']['vite'],
+): string {
+  const output = viteOverrides?.build?.rolldownOptions?.output
+  if (output && typeof output === 'object' && !Array.isArray(output)) {
+    const entryFileNames = output.entryFileNames
+    if (typeof entryFileNames === 'string') {
+      return entryFileNames
+    }
+  }
+  return '[name].js'
 }
 
 /**
@@ -77,33 +129,28 @@ export function resolveRendererOptions(
  * 文字列、配列、名前付き map のいずれも受け入れ、最終的には重複と予約語を検証済みの
  * map へ変換する。
  *
- * @param preload 利用者が与えた preload 設定
+ * @param preload 利用者が与えた preload entry 入力
  * @returns 正規化済み preload entry map
  */
 export function normalizePreloadEntries(
-  preload: ElectronPreloadOptions | undefined,
+  preload: ElectronPreloadInput | undefined,
 ): ElectronPreloadEntryMap {
   if (!preload) {
     return {}
   }
 
   if (typeof preload === 'string') {
-    return createValidatedPreloadEntryMap([
-      [inferPreloadEntryName(preload), preload],
-    ])
+    return createValidatedPreloadEntryMap([[inferEntryName(preload), preload]])
   }
 
   if (Array.isArray(preload)) {
     return createValidatedPreloadEntryMap(
       preload.map((entry) => {
         if (typeof entry === 'string') {
-          return [inferPreloadEntryName(entry), entry] as const
+          return [inferEntryName(entry), entry] as const
         }
 
-        return [
-          entry.name ?? inferPreloadEntryName(entry.entry),
-          entry.entry,
-        ] as const
+        return [entry.name ?? inferEntryName(entry.entry), entry.entry] as const
       }),
     )
   }
@@ -141,17 +188,11 @@ export function createValidatedPreloadEntryMap(
  *
  * @param name preload entry 名
  * @param source source path
- * @throws 予約語、空文字、パス区切りを含む名前などが見つかった場合
+ * @throws 空文字、パス区切りを含む名前などが見つかった場合
  */
 export function validatePreloadEntry(name: string, source: string): void {
   if (!name) {
     throw new Error('Preload entry names must not be empty')
-  }
-
-  if (name === MAIN_ENTRY_NAME) {
-    throw new Error(
-      `The preload entry name "${MAIN_ENTRY_NAME}" is reserved for the Electron main entry`,
-    )
   }
 
   if (name.includes('/') || name.includes('\\')) {
@@ -166,13 +207,15 @@ export function validatePreloadEntry(name: string, source: string): void {
 }
 
 /**
- * source path の basename から preload entry 名を推論する。
+ * source path の basename から entry 名を推論する。
  *
- * @param entryPath preload source path
+ * main / preload 両方で共通に使用する。
+ *
+ * @param entryPath source path
  * @returns 拡張子を除いた entry 名
  * @throws 名前を推論できない場合
  */
-export function inferPreloadEntryName(entryPath: string): string {
+export function inferEntryName(entryPath: string): string {
   const fileName = basename(entryPath)
   const extension = extname(fileName)
   const inferredName = extension
@@ -180,7 +223,7 @@ export function inferPreloadEntryName(entryPath: string): string {
     : fileName
 
   if (!inferredName) {
-    throw new Error(`Could not infer a preload entry name from "${entryPath}"`)
+    throw new Error(`Could not infer an entry name from "${entryPath}"`)
   }
 
   return inferredName
@@ -318,14 +361,36 @@ export function isSuccessfulWindowsTaskkillExitCode(
 /**
  * Vite dev server が無視すべき Electron 出力ディレクトリの glob を返す。
  *
- * @param outDir Electron 出力ディレクトリ
+ * main / preload が個別の outDir を持つ場合はすべてを ignore 対象に含める。
+ *
+ * @param resolvedOptions 解決済みの plugin オプション
  * @param cwd 相対化の基準ディレクトリ
  * @returns watch ignore へ渡す glob 配列
  */
 export function createOutDirIgnorePatterns(
-  outDir: string,
+  resolvedOptions: Pick<
+    ResolvedElectronPluginOptions,
+    'outDir' | 'mainOutDir' | 'preloadOutDir'
+  >,
   cwd: string = process.cwd(),
 ): string[] {
+  const dirs = new Set([
+    resolvedOptions.outDir,
+    resolvedOptions.mainOutDir,
+    resolvedOptions.preloadOutDir,
+  ])
+
+  return [...dirs].flatMap((dir) => createIgnorePatternsForDir(dir, cwd))
+}
+
+/**
+ * 単一のディレクトリに対する watch ignore glob を返す。
+ *
+ * @param outDir 無視対象のディレクトリ
+ * @param cwd 相対化の基準ディレクトリ
+ * @returns glob 配列
+ */
+function createIgnorePatternsForDir(outDir: string, cwd: string): string[] {
   const normalizedOutDir = normalizeGlobPath(
     relative(cwd, resolve(cwd, outDir)),
   )

--- a/packages/vite-plugin-electron/src/types.ts
+++ b/packages/vite-plugin-electron/src/types.ts
@@ -1,3 +1,5 @@
+import type { UserConfig } from 'vite'
+
 /**
  * Rollup watcher から受け取るイベントのうち、この plugin が参照する最小形。
  */
@@ -14,33 +16,11 @@ export const ELECTRON_PRELOAD_ENVIRONMENT_NAME = 'electron_preload'
 export const ELECTRON_OUT_DIR = 'dist-electron'
 /** renderer dev server URL を Electron へ渡す既定の環境変数名。 */
 export const DEFAULT_RENDERER_DEV_SERVER_URL_ENV_VAR = 'VITE_DEV_SERVER_URL'
-/** Electron main entry の論理名。 */
-export const MAIN_ENTRY_NAME = 'main'
-/** Electron main entry の既定パス。 */
-export const DEFAULT_MAIN_ENTRY = 'electron/main.ts'
 
 /** plugin 内で扱う Electron custom environment 名の union。 */
 export type ElectronEnvironmentName =
   | typeof ELECTRON_MAIN_ENVIRONMENT_NAME
   | typeof ELECTRON_PRELOAD_ENVIRONMENT_NAME
-
-/**
- * Electron build に対して利用者へ公開する設定項目。
- *
- * entry 解決や出力ファイル名のように plugin 側で責務を持つ値はここへ含めない。
- */
-export type ElectronBuildOptions = {
-  outDir?: string
-  emptyOutDir?: boolean
-  copyPublicDir?: boolean
-  emitAssets?: boolean
-  minify?: boolean | 'esbuild' | 'terser'
-  reportCompressedSize?: boolean
-  sourcemap?: boolean | 'inline' | 'hidden'
-  target?: string | string[]
-  external?: string[]
-  chunkFileNames?: string
-}
 
 /** dev 中の Electron debugger 接続を制御する公開設定。 */
 export type ElectronDebugOptions = {
@@ -72,17 +52,40 @@ export type ElectronPreloadEntry =
       entry: string
     }
 
-/** preload 設定として受け取れる入力形式の union。 */
-export type ElectronPreloadOptions =
+/**
+ * preload entry として受け取れる入力形式の union。
+ *
+ * 文字列、配列、名前付き map のいずれも受け入れる。
+ */
+export type ElectronPreloadInput =
   | ElectronPreloadEntry
   | ElectronPreloadEntry[]
   | ElectronPreloadEntryMap
 
+/**
+ * Electron main process の設定。
+ *
+ * entry に main process の source path を指定し、vite で Vite 設定を個別に上書きできる。
+ */
+export type ElectronMainOptions = {
+  entry: string
+  vite?: UserConfig
+}
+
+/**
+ * Electron preload script の設定。
+ *
+ * entry に preload source を指定し、vite で Vite 設定を個別に上書きできる。
+ */
+export type ElectronPreloadOptions = {
+  entry: ElectronPreloadInput
+  vite?: UserConfig
+}
+
 /** plugin 利用者へ公開する最上位オプション。 */
 export type ElectronPluginOptions = {
-  main?: string
+  main: ElectronMainOptions
   preload?: ElectronPreloadOptions
-  build?: ElectronBuildOptions
   debug?: boolean | ElectronDebugOptions
   renderer?: ElectronRendererOptions
 }
@@ -112,10 +115,14 @@ export type ResolvedElectronRendererOptions = {
 export type ResolvedElectronPluginOptions = {
   rootDir: string
   mainEntry: string
+  mainEntryName: string
+  mainViteOverrides: UserConfig
   preloadEntries: ElectronPreloadEntryMap
-  buildOptions: ElectronBuildOptions
+  preloadViteOverrides: UserConfig
   debugOptions: ResolvedElectronDebugOptions
   rendererOptions: ResolvedElectronRendererOptions
   outDir: string
+  mainOutDir: string
+  preloadOutDir: string
   mainOutputPath: string
 }

--- a/packages/vite-plugin-electron/tests/electron.test.ts
+++ b/packages/vite-plugin-electron/tests/electron.test.ts
@@ -71,10 +71,46 @@ describe('electron plugin', () => {
   })
 
   it('watch ignore pattern に custom outDir を反映する', () => {
+    // Arrange
+    const resolved = resolveElectronPluginOptions(
+      {
+        main: {
+          entry: 'electron/main.ts',
+          vite: { build: { outDir: 'build-electron' } },
+        },
+      },
+      TEST_CWD,
+    )
+
     // Act
-    expect(createOutDirIgnorePatterns('build-electron', TEST_CWD)).toEqual([
+    expect(createOutDirIgnorePatterns(resolved, TEST_CWD)).toContain(
       '**/build-electron/**',
-    ])
+    )
+  })
+
+  it('main と preload で異なる outDir を指定すると両方の ignore pattern を返す', () => {
+    // Arrange
+    const resolved = resolveElectronPluginOptions(
+      {
+        main: {
+          entry: 'electron/main.ts',
+          vite: { build: { outDir: 'dist-electron/main' } },
+        },
+        preload: {
+          entry: 'electron/preload.ts',
+          vite: { build: { outDir: 'dist-electron/preload' } },
+        },
+      },
+      TEST_CWD,
+    )
+
+    // Act
+    const patterns = createOutDirIgnorePatterns(resolved, TEST_CWD)
+
+    // Assert
+    expect(patterns).toContain('**/dist-electron/**')
+    expect(patterns).toContain('**/dist-electron/main/**')
+    expect(patterns).toContain('**/dist-electron/preload/**')
   })
 
   it('preload の有無に応じて watch 対象 environment を切り替える', () => {
@@ -86,11 +122,35 @@ describe('electron plugin', () => {
     ])
   })
 
-  it('main environment を固定の main.js な ES module 出力として組み立てる', () => {
+  it('main entry 名を入力ファイルの basename から推論する', () => {
+    // Arrange / Act / Assert
+    const fromFile = resolveElectronPluginOptions(
+      { main: { entry: 'electron/main.ts' } },
+      TEST_CWD,
+    )
+    expect(fromFile.mainEntryName).toBe('main')
+    expect(fromFile.mainOutputPath).toBe(
+      resolve(TEST_CWD, 'dist-electron/main.js'),
+    )
+
+    const fromIndex = resolveElectronPluginOptions(
+      { main: { entry: 'electron/main/index.ts' } },
+      TEST_CWD,
+    )
+    expect(fromIndex.mainEntryName).toBe('index')
+    expect(fromIndex.mainOutputPath).toBe(
+      resolve(TEST_CWD, 'dist-electron/index.js'),
+    )
+  })
+
+  it('main environment を入力ファイル名に基づいた ES module 出力として組み立てる', () => {
     // Arrange
     const config = createElectronEnvironmentBuildConfig(
       'electron_main',
-      resolveElectronPluginOptions({}, TEST_CWD),
+      resolveElectronPluginOptions(
+        { main: { entry: 'electron/main.ts' } },
+        TEST_CWD,
+      ),
     )
 
     // Assert
@@ -112,13 +172,16 @@ describe('electron plugin', () => {
       'electron_preload',
       resolveElectronPluginOptions(
         {
-          preload: [
-            'electron/preload.ts',
-            {
-              name: 'settings',
-              entry: 'electron/settings-preload.ts',
-            },
-          ],
+          main: { entry: 'electron/main.ts' },
+          preload: {
+            entry: [
+              'electron/preload.ts',
+              {
+                name: 'settings',
+                entry: 'electron/settings-preload.ts',
+              },
+            ],
+          },
         },
         TEST_CWD,
       ),
@@ -150,9 +213,10 @@ describe('electron plugin', () => {
       'electron_preload',
       resolveElectronPluginOptions(
         {
-          preload: 'electron/preload.ts',
-          build: {
-            emptyOutDir: true,
+          main: { entry: 'electron/main.ts' },
+          preload: {
+            entry: 'electron/preload.ts',
+            vite: { build: { emptyOutDir: true } },
           },
         },
         TEST_CWD,
@@ -161,6 +225,210 @@ describe('electron plugin', () => {
 
     // Assert
     expect(config.build?.emptyOutDir).toBe(false)
+  })
+
+  it('main.vite で出力ファイル名を上書きできる', () => {
+    // Arrange
+    const resolved = resolveElectronPluginOptions(
+      {
+        main: {
+          entry: 'electron/main/index.ts',
+          vite: {
+            build: {
+              rolldownOptions: {
+                output: { entryFileNames: 'main/[name].js' },
+              },
+            },
+          },
+        },
+      },
+      TEST_CWD,
+    )
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolved,
+    )
+
+    // Assert
+    expect(resolved.mainEntryName).toBe('index')
+    const mainInput = config.build?.rolldownOptions?.input as Record<
+      string,
+      string
+    >
+    expect(mainInput).toHaveProperty('index')
+    expect(config.build?.rolldownOptions?.output).toMatchObject({
+      entryFileNames: 'main/[name].js',
+      format: 'es',
+    })
+  })
+
+  it('preload.vite で出力ファイル名とフォーマットを上書きできる', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_preload',
+      resolveElectronPluginOptions(
+        {
+          main: { entry: 'electron/main.ts' },
+          preload: {
+            entry: 'electron/preload.ts',
+            vite: {
+              build: {
+                rolldownOptions: {
+                  output: {
+                    entryFileNames: 'preload/[name].cjs',
+                    format: 'cjs',
+                  },
+                },
+              },
+            },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    expect(config.build?.rolldownOptions?.output).toMatchObject({
+      entryFileNames: 'preload/[name].cjs',
+      format: 'cjs',
+    })
+  })
+
+  it('main.vite で outDir を個別指定できる', () => {
+    // Arrange
+    const resolved = resolveElectronPluginOptions(
+      {
+        main: {
+          entry: 'electron/main/index.ts',
+          vite: { build: { outDir: 'dist-electron/main' } },
+        },
+        preload: {
+          entry: 'electron/preload/index.ts',
+          vite: { build: { outDir: 'dist-electron/preload' } },
+        },
+      },
+      TEST_CWD,
+    )
+
+    // Assert
+    expect(resolved.mainOutDir).toBe('dist-electron/main')
+    expect(resolved.preloadOutDir).toBe('dist-electron/preload')
+
+    const mainConfig = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolved,
+    )
+    expect(mainConfig.build?.outDir).toBe('dist-electron/main')
+
+    const preloadConfig = createElectronEnvironmentBuildConfig(
+      'electron_preload',
+      resolved,
+    )
+    expect(preloadConfig.build?.outDir).toBe('dist-electron/preload')
+  })
+
+  it('vite override の external はユーザー指定と electron を結合する', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: {
+            entry: 'electron/main.ts',
+            vite: {
+              build: {
+                rolldownOptions: {
+                  external: ['better-sqlite3'],
+                },
+              },
+            },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    const external = config.build?.rolldownOptions?.external as string[]
+    expect(external).toContain('electron')
+    expect(external).toContain('better-sqlite3')
+  })
+
+  it('vite override で input を指定しても plugin が上書きする', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: {
+            entry: 'electron/main.ts',
+            vite: {
+              build: {
+                rolldownOptions: {
+                  input: { wrong: 'should-be-ignored.ts' },
+                },
+              },
+            },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    const input = config.build?.rolldownOptions?.input as Record<string, string>
+    expect(p(input?.main ?? '')).toContain('electron/main.ts')
+    expect(input).not.toHaveProperty('wrong')
+  })
+
+  it('vite override で sourcemap と target を上書きできる', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: {
+            entry: 'electron/main.ts',
+            vite: {
+              build: {
+                sourcemap: false,
+                target: 'node20',
+              },
+            },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    expect(config.build?.sourcemap).toBe(false)
+    expect(config.build?.target).toBe('node20')
+  })
+
+  it('mainOutputPath が vite override の outDir と entryFileNames を反映する', () => {
+    // Arrange
+    const resolved = resolveElectronPluginOptions(
+      {
+        main: {
+          entry: 'electron/main/index.ts',
+          vite: {
+            build: {
+              outDir: 'dist-electron/main',
+              rolldownOptions: {
+                output: { entryFileNames: 'app/[name].js' },
+              },
+            },
+          },
+        },
+      },
+      TEST_CWD,
+    )
+
+    // Assert
+    expect(resolved.mainOutputPath).toBe(
+      resolve(TEST_CWD, 'dist-electron/main/app/index.js'),
+    )
   })
 
   it('debug 設定から既定値と引数を解決する', () => {
@@ -478,9 +746,9 @@ describe('electron plugin', () => {
     // Arrange
     const resolved = resolveElectronPluginOptions(
       {
-        main: 'electron/custom-main.ts',
-        build: {
-          outDir: 'build-electron',
+        main: {
+          entry: 'electron/custom-main.ts',
+          vite: { build: { outDir: 'build-electron' } },
         },
       },
       TEST_CWD_DEEP,
@@ -490,11 +758,13 @@ describe('electron plugin', () => {
     expect(resolved.mainEntry).toBe(
       resolve(TEST_CWD_DEEP, 'electron/custom-main.ts'),
     )
+    expect(resolved.mainEntryName).toBe('custom-main')
     expect(resolved.mainOutputPath).toBe(
-      resolve(TEST_CWD_DEEP, 'build-electron/main.js'),
+      resolve(TEST_CWD_DEEP, 'build-electron/custom-main.js'),
     )
     expect(resolved.rootDir).toBe(TEST_CWD_DEEP)
-    expect(resolved.outDir).toBe('build-electron')
+    expect(resolved.outDir).toBe('dist-electron')
+    expect(resolved.mainOutDir).toBe('build-electron')
   })
 
   it('preload の不正設定を option 解決時に検出する', () => {
@@ -502,18 +772,10 @@ describe('electron plugin', () => {
     expect(() =>
       resolveElectronPluginOptions(
         {
+          main: { entry: 'electron/main.ts' },
           preload: {
-            main: 'electron/preload.ts',
+            entry: ['electron/preload.ts', 'src/preload.ts'],
           },
-        },
-        TEST_CWD,
-      ),
-    ).toThrow(/reserved/)
-
-    expect(() =>
-      resolveElectronPluginOptions(
-        {
-          preload: ['electron/preload.ts', 'src/preload.ts'],
         },
         TEST_CWD,
       ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,6 +1075,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}


### PR DESCRIPTION
## 概要

- Electron プラグインで、main と preload それぞれに個別の Vite 設定を渡せるようにし、サンプル設定も新しい API に合わせて更新します。
- 破壊的変更があります。公開オプションの形が変わり、従来の main: 文字列 と build がそのままでは使えません。

## 変更内容

- ElectronPluginOptions を再設計し、main を必須のオブジェクト化、preload も entry と vite を持つ構造へ変更します。
- 共有の build 設定を廃止し、main.vite と preload.vite を environment ごとに mergeConfig でマージする実装へ切り替えます。
- main の出力名を固定の main.js ではなく entry の basename から推論するようにし、mainOutputPath もそれに追従させます。
- watch ignore は単一 outDir 前提をやめ、共通 outDir・mainOutDir・preloadOutDir をまとめて除外できるようにします。
- 例として example-single と example-multiple の vite.config.ts を新 API に更新します。
- 公開型とテストを更新し、types.ts で新しい型を追加、electron.test.ts で override・outDir・input 優先制御などを検証します。
- pnpm-lock.yaml には依存解決に伴うメタデータ更新が 1 件入っています。

## 影響範囲

- 破壊的変更あり。プラグイン利用側の設定コードは main と preload の書き方を変更する必要があります。
- main の出力ファイル名が entry 名に依存するため、main.js 固定を前提にした利用や参照がある場合は見直しが必要です。
- preload はユーザー override で emptyOutDir を指定しても false に補正されるため、その挙動を前提にしたレビューが必要です。
- 権限、認証、課金、削除、マイグレーションの変更は差分上は不明です。
- 設定変更はあります。公開 API とビルド出力の意味が変わるため、利用者影響は比較的大きいです。

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm dev:single, pnpm dev:multiple で起動できる
- [x] pnpm preview:single, pnpm preview:multiple でビルドして exe を起動できる

## レビュー観点

- 既存利用者に対して破壊的変更の告知粒度が十分か。特に build 廃止、main 必須化、preload の構造変更、electron(options) の呼び出し前提を確認したいです。
- mergeConfig 後に input と emptyOutDir を再上書きしているため、ユーザー override とプラグイン強制値の境界が意図どおりかを確認したいです。
- main の entry basename を出力名に使う仕様が、既存の開発フローや配布フローに副作用を出さないかを確認したいです。
- watch ignore の対象追加で、分離 outDir 構成時の再ビルドループが確実に防げているかを確認したいです。

## 関連リンク

- なし
