### PR TITLE
build: 公開向けパッケージ設定とワークスペース名を整理 0.2.0-beta.1

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,6 +7,6 @@
   "sortImports": {
     "newlinesBetween": true,
     "order": "asc",
-    "internalPattern": ["@srymh"]
+    "internalPattern": ["@repo"]
   }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 srymh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/example-multiple/desktop/package.json
+++ b/example-multiple/desktop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@srymh/desktop",
+  "name": "@repo/multi-desktop",
   "version": "0.0.0",
   "private": true,
   "description": "",
@@ -16,7 +16,7 @@
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
-    "@srymh/electron-api": "workspace:*"
+    "@repo/multi-electron-api": "workspace:*"
   },
   "devDependencies": {
     "@srymh/vite-plugin-electron": "workspace:*",

--- a/example-multiple/desktop/src/preload.ts
+++ b/example-multiple/desktop/src/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge } from 'electron'
 
-import type { ElectronApi } from '@srymh/electron-api'
+import type { ElectronApi } from '@repo/multi-electron-api'
 
 const electronApi: ElectronApi = {
   platform: process.platform,

--- a/example-multiple/desktop/vite.config.ts
+++ b/example-multiple/desktop/vite.config.ts
@@ -1,9 +1,8 @@
-import { defineConfig } from 'vite'
-
 import {
   electron,
   type ElectronPluginOptions,
 } from '@srymh/vite-plugin-electron'
+import { defineConfig } from 'vite'
 
 const electronOptions: ElectronPluginOptions = {
   main: {

--- a/example-multiple/electron-api/package.json
+++ b/example-multiple/electron-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@srymh/electron-api",
+  "name": "@repo/multi-electron-api",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/example-multiple/web/README.md
+++ b/example-multiple/web/README.md
@@ -1,4 +1,4 @@
-# @srymh/web
+# @repo/multi-web
 
 example-multiple の renderer アプリです。React + Vite で構成されており、example-multiple/desktop から external renderer として利用されます。
 

--- a/example-multiple/web/package.json
+++ b/example-multiple/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@srymh/web",
+  "name": "@repo/multi-web",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@srymh/electron-api": "workspace:*",
+    "@repo/multi-electron-api": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/example-multiple/web/src/electron-api.d.ts
+++ b/example-multiple/web/src/electron-api.d.ts
@@ -1,4 +1,4 @@
-import type { ElectronApi } from '@srymh/electron-api'
+import type { ElectronApi } from '@repo/multi-electron-api'
 
 declare global {
   interface Window {

--- a/example-single/README.md
+++ b/example-single/README.md
@@ -1,4 +1,4 @@
-# @srymh/single
+# @repo/single
 
 renderer と Electron main/preload を 1 package に同居させた、最小構成のサンプルです。
 

--- a/example-single/package.json
+++ b/example-single/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@srymh/single",
+  "name": "@repo/single",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/example-single/vite.config.ts
+++ b/example-single/vite.config.ts
@@ -1,8 +1,7 @@
+import { electron } from '@srymh/vite-plugin-electron'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import Inspect from 'vite-plugin-inspect'
-
-import { electron } from '@srymh/vite-plugin-electron'
 
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({

--- a/package.json
+++ b/package.json
@@ -1,13 +1,6 @@
 {
   "name": "vite-plugin-electron",
   "private": true,
-  "keywords": [
-    "electron",
-    "plugin",
-    "vite"
-  ],
-  "license": "MIT",
-  "author": "srymh",
   "type": "module",
   "scripts": {
     "build": "pnpm --filter @srymh/vite-plugin-electron build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.0.0",
   "private": true,
   "keywords": [
     "electron",
@@ -13,14 +12,14 @@
   "scripts": {
     "build": "pnpm --filter @srymh/vite-plugin-electron build",
     "test": "pnpm --filter @srymh/vite-plugin-electron test",
-    "dev:single": "pnpm --filter @srymh/single dev",
-    "build:single": "pnpm --filter @srymh/single build",
-    "preview:single": "pnpm --filter @srymh/single build && pnpm --filter @srymh/single preview",
-    "package:single": "pnpm --filter @srymh/single package",
-    "dev:multiple": "pnpm --parallel --filter @srymh/web --filter @srymh/desktop run dev",
-    "build:multiple": "pnpm --filter @srymh/web build && pnpm --filter @srymh/desktop build",
-    "preview:multiple": "pnpm build:multiple && pnpm --filter @srymh/desktop preview",
-    "package:multiple": "pnpm build:multiple && pnpm --filter @srymh/desktop package",
+    "dev:single": "pnpm --filter @repo/single dev",
+    "build:single": "pnpm --filter @repo/single build",
+    "preview:single": "pnpm --filter @repo/single build && pnpm --filter @repo/single preview",
+    "package:single": "pnpm --filter @repo/single package",
+    "dev:multiple": "pnpm --parallel --filter @repo/multi-web --filter @repo/multi-desktop run dev",
+    "build:multiple": "pnpm --filter @repo/multi-web build && pnpm --filter @repo/multi-desktop build",
+    "preview:multiple": "pnpm build:multiple && pnpm --filter @repo/multi-desktop preview",
+    "package:multiple": "pnpm build:multiple && pnpm --filter @repo/multi-desktop package",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check"
   },

--- a/packages/vite-plugin-electron/LICENSE
+++ b/packages/vite-plugin-electron/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 srymh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vite-plugin-electron/package.json
+++ b/packages/vite-plugin-electron/package.json
@@ -1,14 +1,23 @@
 {
   "name": "@srymh/vite-plugin-electron",
-  "version": "0.1.0",
-  "private": true,
+  "version": "0.2.0-beta.1",
+  "description": "Vite 8 Environment API based plugin for integrating Electron main/preload build",
   "keywords": [
     "electron",
-    "plugin",
-    "vite"
+    "vite",
+    "vite-plugin"
   ],
+  "homepage": "https://github.com/srymh/vite-plugin-electron/tree/main/packages/vite-plugin-electron#readme",
+  "bugs": {
+    "url": "https://github.com/srymh/vite-plugin-electron/issues"
+  },
   "license": "MIT",
   "author": "srymh",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/srymh/vite-plugin-electron.git",
+    "directory": "packages/vite-plugin-electron"
+  },
   "files": [
     "dist"
   ],
@@ -34,5 +43,11 @@
     "typescript": "~6.0.2",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"
+  },
+  "peerDependencies": {
+    "vite": "^8.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/packages/vite-plugin-electron/tsdown.config.ts
+++ b/packages/vite-plugin-electron/tsdown.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   outDir: 'dist',
   platform: 'node',
   target: 'node20',
-  sourcemap: true,
+  sourcemap: false,
+  minify: true,
   clean: true,
   deps: {
     skipNodeModulesBundle: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
 
   example-multiple/desktop:
     dependencies:
-      '@srymh/electron-api':
+      '@repo/multi-electron-api':
         specifier: workspace:*
         version: link:../electron-api
     devDependencies:
@@ -41,7 +41,7 @@ importers:
 
   example-multiple/web:
     dependencies:
-      '@srymh/electron-api':
+      '@repo/multi-electron-api':
         specifier: workspace:*
         version: link:../electron-api
       react:


### PR DESCRIPTION
## 概要

- プラグインの公開向け設定を追加し、ワークスペース内のパッケージ名と実行スクリプトを整理

## 変更内容

- packages/vite-plugin-electron の package.json に description、homepage、bugs、repository、peerDependencies、engines を追加し、バージョンを 0.2.0-beta.1 に更新
- packages/vite-plugin-electron に LICENSE を追加し、tsdown.config.ts で sourcemap を無効化して minify を有効化
- example-multiple と example-single のパッケージ名を @repo 系へ変更し、参照先 import とルート scripts、pnpm-lock.yaml を追従
- .oxfmtrc.json の internalPattern を @repo に変更し、新しいワークスペース命名に合わせて整合

## 影響範囲

- packages/vite-plugin-electron の公開設定が変わるため、配布物の構成と npm 上のメタデータに影響する
- example 用ワークスペース名と root scripts が変わるため、従来の @srymh/* 名を前提にしたローカル運用がある場合は修正が必要
- Node.js >=20.0.0 と Vite ^8.0.0 を前提にする設定が追加される

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm build` でビルドできる

## レビュー観点

- ワークスペース名変更に伴って、example 側の依存参照とルート scripts の置換漏れがないか
- npm 公開時に LICENSE、peerDependencies、engines、repository 情報が意図どおり反映されるか
- minify 有効化と sourcemap 無効化がデバッグ運用に問題ないか

## 関連リンク

- なし