### PR TITLE
chore: 0.2.0-beta.2 向けにバージョン更新と README 導線を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vite-plugin-electron
 
+[![npm version](https://img.shields.io/npm/v/@srymh/vite-plugin-electron.svg)](https://npmjs.com/package/@srymh/vite-plugin-electron)
+
 Vite 8 の Environment API を使って Electron main/preload プロセスのビルドを統合するプラグインと、その利用例をまとめた pnpm workspace です。
 
 ## パッケージ

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vite-plugin-electron"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 description = "Vite 8 Environment API based plugin for integrating Electron main/preload build"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/vite-plugin-electron/README.md
+++ b/packages/vite-plugin-electron/README.md
@@ -122,12 +122,12 @@ pnpm lint    # oxlint
 
 ## Further Reading
 
-- [Getting Started](../../docs/docs/getting-started.md)
-- [Build / Dev Guide](../../docs/docs/guide.md)
-- [Options Reference](../../docs/docs/options.md)
-- [Internal Architecture](../../docs/docs/architecture.md)
-- [VS Code Debug](../../docs/docs/vscode-debug.md)
-- [Scope & Responsibilities](../../docs/docs/scope.md)
+- [Getting Started](https://srymh.github.io/vite-plugin-electron/getting-started/)
+- [Build / Dev Guide](https://srymh.github.io/vite-plugin-electron/guide/)
+- [Options Reference](https://srymh.github.io/vite-plugin-electron/options/)
+- [Internal Architecture](https://srymh.github.io/vite-plugin-electron/architecture/)
+- [VS Code Debug](https://srymh.github.io/vite-plugin-electron/vscode-debug/)
+- [Scope & Responsibilities](https://srymh.github.io/vite-plugin-electron/scope/)
 
 ## License
 

--- a/packages/vite-plugin-electron/README_ja.md
+++ b/packages/vite-plugin-electron/README_ja.md
@@ -122,12 +122,12 @@ pnpm lint    # oxlint
 
 ## さらに詳しく
 
-- [はじめに](../../docs/docs/getting-started.md)
-- [ビルド・開発ガイド](../../docs/docs/guide.md)
-- [オプション詳細](../../docs/docs/options.md)
-- [内部アーキテクチャ](../../docs/docs/architecture.md)
-- [VS Code デバッグ](../../docs/docs/vscode-debug.md)
-- [責務とスコープ](../../docs/docs/scope.md)
+- [はじめに](https://srymh.github.io/vite-plugin-electron/getting-started/)
+- [ビルド・開発ガイド](https://srymh.github.io/vite-plugin-electron/guide/)
+- [オプション詳細](https://srymh.github.io/vite-plugin-electron/options/)
+- [内部アーキテクチャ](https://srymh.github.io/vite-plugin-electron/architecture/)
+- [VS Code デバッグ](https://srymh.github.io/vite-plugin-electron/vscode-debug/)
+- [責務とスコープ](https://srymh.github.io/vite-plugin-electron/scope/)
 
 ## License
 

--- a/packages/vite-plugin-electron/package.json
+++ b/packages/vite-plugin-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srymh/vite-plugin-electron",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "description": "Vite 8 Environment API based plugin for integrating Electron main/preload build",
   "keywords": [
     "electron",


### PR DESCRIPTION
## 概要

- 0.2.0-beta.2 リリース向けにパッケージとドキュメントのバージョン表記を更新
- README に npm バージョンバッジを追加
- パッケージ README のドキュメント導線を公開サイト URL に統一

## 変更内容

- package.json の version を 0.2.0-beta.2 に更新
- pyproject.toml の version を 0.2.0-beta.2 に更新
- README.md に npm バージョンバッジを追加
- README.md の Further Reading を相対パスから公開ドキュメント URL に変更
- README_ja.md の さらに詳しく を相対パスから公開ドキュメント URL に変更

## 影響範囲

- npm 公開時のバージョン表記
- README からのドキュメント遷移
- 実装コード、ランタイム挙動、テストコードへの変更はなし

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm build が成功する

## レビュー観点

- 公開ドキュメント URL が想定どおりのページを指しているか
- npm バッジのリンク先とパッケージ名が正しいか
- バージョン番号 0.2.0-beta.2 が package.json と pyproject.toml で一致しているか

## 関連リンク

- なし