### PR TITLE
fix(vite-plugin-electron): Electron 起動時に package.json の名前を正しく解決する

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,5 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["AGENTS.md"],
   "semi": false,
   "singleQuote": true,
   "printWidth": 80,
@@ -8,5 +7,12 @@
     "newlinesBetween": true,
     "order": "asc",
     "internalPattern": ["@repo"]
-  }
+  },
+  "ignorePatterns": [
+    "AGENTS.md",
+    "README.md",
+    "README_ja.md",
+    "docs/**",
+    ".*/**"
+  ]
 }

--- a/example-multiple/desktop/package.json
+++ b/example-multiple/desktop/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
-    "preview": "electron dist/main.js",
+    "preview": "electron .",
     "package": "electron-builder --publish never",
     "postinstall": "electron-builder install-app-deps"
   },

--- a/example-single/package.json
+++ b/example-single/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "electron dist-electron/main.js",
+    "preview": "electron .",
     "package": "pnpm build && electron-builder",
     "postinstall": "electron-builder install-app-deps"
   },

--- a/packages/vite-plugin-electron/src/dev.ts
+++ b/packages/vite-plugin-electron/src/dev.ts
@@ -44,7 +44,7 @@ type ElectronDevSession = {
 type ElectronDevOptions = {
   preloadEntries: ElectronPreloadEntryMap
   debug: ResolvedElectronDebugOptions
-  mainOutputPath: string
+  rootDir: string
   rendererDevUrl?: string
   rendererDevUrlEnvVar: string
   onRestart: (childProcess: ChildProcess) => void
@@ -233,7 +233,7 @@ async function startElectronDevSession(
           currentElectronProcess,
           {
             debug: options.debug,
-            mainOutputPath: options.mainOutputPath,
+            rootDir: options.rootDir,
             devServerUrl,
             devServerUrlEnvVar: options.rendererDevUrlEnvVar,
           },

--- a/packages/vite-plugin-electron/src/electron.ts
+++ b/packages/vite-plugin-electron/src/electron.ts
@@ -15,6 +15,7 @@ import {
 import {
   createOutDirIgnorePatterns,
   resolveElectronPluginOptions,
+  validatePackageJsonMainField,
 } from './options'
 import {
   ELECTRON_MAIN_ENVIRONMENT_NAME,
@@ -176,10 +177,15 @@ export function electron(options: ElectronPluginOptions): Plugin {
      * @param server Vite dev server
      */
     async configureServer(server) {
+      validatePackageJsonMainField(
+        resolvedOptions.rootDir,
+        resolvedOptions.mainOutputPath,
+      )
+
       registerElectronDevServer(server, {
         preloadEntries: resolvedOptions.preloadEntries,
         debug: resolvedOptions.debugOptions,
-        mainOutputPath: resolvedOptions.mainOutputPath,
+        rootDir: resolvedOptions.rootDir,
         rendererDevUrl: resolvedOptions.rendererOptions.devUrl,
         rendererDevUrlEnvVar: resolvedOptions.rendererOptions.devUrlEnvVar,
         onRestart() {},

--- a/packages/vite-plugin-electron/src/options.ts
+++ b/packages/vite-plugin-electron/src/options.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { basename, extname, relative, resolve } from 'node:path'
 import process from 'node:process'
 
@@ -290,17 +291,69 @@ export function getElectronDebugArgs(
 }
 
 /**
- * debug 引数と main 出力パスを結合し、Electron 起動用の argv を返す。
+ * debug 引数とプロジェクトルートを結合し、Electron 起動用の argv を返す。
+ *
+ * ルートディレクトリを渡すことで、Electron がプロジェクトの package.json を読み取り、
+ * `app.getName()` や `app.getPath('userData')` を正しく解決できるようにする。
  *
  * @param debug 解決済み debug 設定
- * @param mainOutputPath 実行対象の Electron main 出力ファイル
+ * @param rootDir Electron に渡すプロジェクトルートディレクトリ
  * @returns `spawn(electron, args)` に渡す配列
  */
 export function getElectronSpawnArgs(
   debug: ResolvedElectronDebugOptions,
-  mainOutputPath: string,
+  rootDir: string,
 ): string[] {
-  return [...getElectronDebugArgs(debug), mainOutputPath]
+  return [...getElectronDebugArgs(debug), rootDir]
+}
+
+/**
+ * プロジェクトの package.json の `main` フィールドが Electron main の出力パスと一致するか検証する。
+ *
+ * Electron はプロジェクトルートを引数として受け取ると、package.json の `main` フィールドから
+ * エントリーポイントを解決する。`main` が正しく設定されていない場合、Electron は起動に失敗するか
+ * 予期しないファイルを実行してしまう。
+ *
+ * @param rootDir プロジェクトルートディレクトリ
+ * @param mainOutputPath plugin が算出した Electron main の出力パス
+ * @throws package.json が存在しない、`main` フィールドが未設定、または出力パスと不一致の場合
+ */
+export function validatePackageJsonMainField(
+  rootDir: string,
+  mainOutputPath: string,
+): void {
+  const packageJsonPath = resolve(rootDir, 'package.json')
+
+  let content: string
+  try {
+    content = readFileSync(packageJsonPath, 'utf-8')
+  } catch {
+    throw new Error(
+      `[vite-plugin-electron] ${packageJsonPath} が見つかりません。` +
+        ' Electron はプロジェクトルートの package.json からアプリ名とエントリーポイントを解決します。',
+    )
+  }
+
+  const packageJson = JSON.parse(content) as { main?: string }
+  const mainField = packageJson.main
+
+  if (!mainField) {
+    throw new Error(
+      '[vite-plugin-electron] package.json に "main" フィールドがありません。' +
+        ` Electron のエントリーポイントとして "main": "${relative(rootDir, mainOutputPath)}" を追加してください。`,
+    )
+  }
+
+  const resolvedMainField = resolve(rootDir, mainField)
+  const resolvedExpected = resolve(mainOutputPath)
+
+  if (resolvedMainField !== resolvedExpected) {
+    throw new Error(
+      `[vite-plugin-electron] package.json の "main" フィールド ("${mainField}") が` +
+        ` Electron main の出力パス ("${relative(rootDir, mainOutputPath)}") と一致しません。` +
+        ` "main": "${relative(rootDir, mainOutputPath)}" に修正してください。`,
+    )
+  }
 }
 
 /**

--- a/packages/vite-plugin-electron/src/process.ts
+++ b/packages/vite-plugin-electron/src/process.ts
@@ -18,7 +18,7 @@ import { type ResolvedElectronDebugOptions } from './types'
  */
 type LaunchElectronProcessOptions = {
   debug: ResolvedElectronDebugOptions
-  mainOutputPath: string
+  rootDir: string
   devServerUrl: string
   devServerUrlEnvVar: string
 }
@@ -70,10 +70,7 @@ export async function restartElectronProcess(
 export function launchElectronProcess(
   options: LaunchElectronProcessOptions,
 ): ChildProcess {
-  const electronArgs = getElectronSpawnArgs(
-    options.debug,
-    options.mainOutputPath,
-  )
+  const electronArgs = getElectronSpawnArgs(options.debug, options.rootDir)
 
   if (options.debug.enabled) {
     console.log(

--- a/packages/vite-plugin-electron/tests/electron.test.ts
+++ b/packages/vite-plugin-electron/tests/electron.test.ts
@@ -1,6 +1,8 @@
-import { resolve } from 'node:path'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   createElectronBuildCoordinator,
@@ -26,6 +28,7 @@ import {
   resolveDebugOptions,
   resolveElectronPluginOptions,
   resolveRendererOptions,
+  validatePackageJsonMainField,
 } from '../src/options'
 
 /** OS 間でパス区切りを揃える正規化ヘルパー */
@@ -460,12 +463,10 @@ describe('electron plugin', () => {
     })
 
     // Act / Assert
-    expect(
-      getElectronSpawnArgs(debug, 'D:/repo/dist-electron/main.js'),
-    ).toEqual([
+    expect(getElectronSpawnArgs(debug, 'D:/repo')).toEqual([
       '--inspect=localhost:9333',
       '--remote-debugging-port=9444',
-      'D:/repo/dist-electron/main.js',
+      'D:/repo',
     ])
     expect(
       getElectronSpawnEnv('http://localhost:5173', 'VITE_DEV_SERVER_URL', {
@@ -780,5 +781,83 @@ describe('electron plugin', () => {
         TEST_CWD,
       ),
     ).toThrow(/Duplicate preload entry name/)
+  })
+
+  describe('validatePackageJsonMainField', () => {
+    let tmpDir: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'vpe-test-'))
+    })
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('package.json の main フィールドが出力パスと一致すればエラーにならない', () => {
+      // Arrange
+      writeFileSync(
+        join(tmpDir, 'package.json'),
+        JSON.stringify({ name: 'my-app', main: './dist-electron/main.js' }),
+      )
+      const mainOutputPath = resolve(tmpDir, 'dist-electron/main.js')
+
+      // Act / Assert
+      expect(() =>
+        validatePackageJsonMainField(tmpDir, mainOutputPath),
+      ).not.toThrow()
+    })
+
+    it('main フィールドが ./ なしでも正しく一致する', () => {
+      // Arrange
+      writeFileSync(
+        join(tmpDir, 'package.json'),
+        JSON.stringify({ name: 'my-app', main: 'dist-electron/main.js' }),
+      )
+      const mainOutputPath = resolve(tmpDir, 'dist-electron/main.js')
+
+      // Act / Assert
+      expect(() =>
+        validatePackageJsonMainField(tmpDir, mainOutputPath),
+      ).not.toThrow()
+    })
+
+    it('main フィールドが出力パスと不一致ならエラーを投げる', () => {
+      // Arrange
+      writeFileSync(
+        join(tmpDir, 'package.json'),
+        JSON.stringify({ name: 'my-app', main: 'dist/index.js' }),
+      )
+      const mainOutputPath = resolve(tmpDir, 'dist-electron/main.js')
+
+      // Act / Assert
+      expect(() =>
+        validatePackageJsonMainField(tmpDir, mainOutputPath),
+      ).toThrow(/一致しません/)
+    })
+
+    it('main フィールドが未設定ならエラーを投げる', () => {
+      // Arrange
+      writeFileSync(
+        join(tmpDir, 'package.json'),
+        JSON.stringify({ name: 'my-app' }),
+      )
+      const mainOutputPath = resolve(tmpDir, 'dist-electron/main.js')
+
+      // Act / Assert
+      expect(() =>
+        validatePackageJsonMainField(tmpDir, mainOutputPath),
+      ).toThrow(/"main" フィールドがありません/)
+    })
+
+    it('package.json が存在しなければエラーを投げる', () => {
+      // Arrange
+      const mainOutputPath = resolve(tmpDir, 'dist-electron/main.js')
+
+      // Act / Assert
+      expect(() =>
+        validatePackageJsonMainField(tmpDir, mainOutputPath),
+      ).toThrow(/見つかりません/)
+    })
   })
 })


### PR DESCRIPTION
- Electron の起動引数を main 出力ファイルからプロジェクトルートへ変更し、package.json の name と main を基準に起動できるよう修正
- dev 起動前に package.json の main フィールドと Electron main 出力パスの一致を検証する処理を追加
- example の preview スクリプトを electron . に変更し、preview 時も package.json を参照する起動方法へ揃えた
- Electron 起動引数の期待値と package.json 検証のテストを追加した