### PR TITLE
fix(debug): VS Codeデバッグの再アタッチ設定を改善

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,7 @@
       "address": "localhost",
       "port": 9229,
       "restart": true,
-      "timeout": 30000,
+      "timeout": 60000,
       "cwd": "${workspaceFolder}/example-single",
       "sourceMaps": true,
       "skipFiles": ["<node_internals>/**"]
@@ -46,9 +46,10 @@
       "request": "attach",
       "address": "localhost",
       "port": 9222,
+      "restart": true,
       "webRoot": "${workspaceFolder}/example-single",
       "sourceMaps": true,
-      "timeout": 30000
+      "timeout": 60000
     },
     {
       "name": "🚀 Launch Monorepo Dev (Multiple Package Example)",
@@ -64,7 +65,7 @@
       "address": "localhost",
       "port": 9229,
       "restart": true,
-      "timeout": 30000,
+      "timeout": 60000,
       "cwd": "${workspaceFolder}/example-multiple/desktop",
       "sourceMaps": true,
       "skipFiles": ["<node_internals>/**"]
@@ -75,9 +76,10 @@
       "request": "attach",
       "address": "localhost",
       "port": 9222,
+      "restart": true,
       "webRoot": "${workspaceFolder}/example-multiple/web",
       "sourceMaps": true,
-      "timeout": 30000
+      "timeout": 60000
     }
   ]
 }

--- a/docs/docs/vscode-debug.md
+++ b/docs/docs/vscode-debug.md
@@ -62,3 +62,43 @@ dev server を別途起動済みの場合、Attach 構成だけを選んで atta
 | renderer (Chrome DevTools) | 9222 | `--remote-debugging-port=9222` |
 
 これらのポートは `debug.port` と `debug.rendererPort` で変更できます。launch.json 側のポートも合わせて変更してください。
+
+## トラブルシューティング
+
+### 初回 attach がタイムアウトする
+
+Compound 構成では、Vite dev server の起動と attach が同時に開始されます。main / preload のビルドが完了して Electron が起動するまで、デバッグポートは開きません。
+
+ビルド時間が長い場合（依存が多い、マシンスペックが低い等）、既定の `timeout: 60000`（60 秒）では不足することがあります。`launch.json` の各 Attach 構成で `timeout` を増やしてください。
+
+```jsonc
+// 例: 120 秒に変更
+"timeout": 120000
+```
+
+### ファイル変更後にデバッガが切断される
+
+このプラグインでは、**main と preload どちらのファイルを変更しても Electron プロセス全体が再起動**されます（preload 変更時も renderer reload ではなく full restart）。再起動すると Node inspector port (9229) と Chrome DevTools port (9222) の両方が一度切断されます。
+
+各 Attach 構成に `"restart": true` を設定しておくと、切断後に自動で再アタッチを試みます。
+
+```jsonc
+// Main attach
+{
+  "type": "node",
+  "request": "attach",
+  "restart": true,  // Electron 再起動時に自動で再アタッチ
+  // ...
+}
+
+// Renderer attach
+{
+  "type": "chrome",
+  "request": "attach",
+  "restart": true,  // Electron 再起動時に自動で再アタッチ
+  // ...
+}
+```
+
+!!! note "preload 変更時の挙動"
+    preload のみを変更した場合でも、main + preload の両方がリビルドされ、Electron プロセスが再起動します。これは現在のプラグインの設計によるもので、renderer の HMR reload ではありません。そのため、Main・Renderer 両方の Attach 構成で `restart: true` が必要です。


### PR DESCRIPTION
- VS Code の Electron デバッグ設定を見直し、attach の安定性を改善
- Main と Renderer の attach timeout を 30 秒から 60 秒へ延長
- Renderer の attach 構成に restart を追加し、再起動後の自動再アタッチに対応
- デバッグドキュメントに timeout 調整方法と restart 設定の意図を追記