### PR TITLE
fix(dev): 共有 outDir で preload 成果物が消える不具合を修正

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -299,7 +299,7 @@ Electron 側 build のうち、plugin 利用者に開いている項目です。
 - `emitAssets`: `false`
 - `reportCompressedSize`: `false`
 
-`emptyOutDir` は main build 側でだけ有効にし、preload build 側では false 固定にしています。これにより main / preload を同じ `outDir` に出しても、お互いの出力を消しにくい構成にしています。
+`emptyOutDir` は preload build 側では常に false 固定です。main build 側は、preload と異なる `outDir` を使う場合にのみ `true` になります。main と preload が同じ `outDir` を共有する場合は main も `false` になり、dev の watch リビルドで preload の成果物が巻き添えに削除されるのを防ぎます。dev session 開始時には出力ディレクトリを 1 回だけクリーンするため、前回の古い成果物が残ることはありません。
 
 注意点として、package 自体の配布ビルド target は [tsdown.config.ts](https://github.com/srymh/vite-plugin-electron/blob/main/packages/vite-plugin-electron/tsdown.config.ts) で `node20`、Electron 側 build の既定 target は plugin option で `node22` です。前者は npm package 用、後者は Electron app 用で役割が異なります。
 

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -222,7 +222,7 @@ main と preload の両方に適用されるビルド設定の既定値:
 | `copyPublicDir` | `false` | — |
 | `emitAssets` | `false` | — |
 | `reportCompressedSize` | `false` | — |
-| `emptyOutDir` | main: `true`, preload: `false` | 同一 outDir でも互いの出力を消さない |
+| `emptyOutDir` | main: `true`（※）, preload: `false` | ※ main と preload が同一 outDir を共有する場合は main も `false` になる |
 
 プラグインが固定する項目（ユーザーが上書きできない）:
 

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vite-plugin-electron"
-version = "0.2.0-beta.2"
+version = "0.2.0-beta.3"
 description = "Vite 8 Environment API based plugin for integrating Electron main/preload build"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/vite-plugin-electron/package.json
+++ b/packages/vite-plugin-electron/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@srymh/vite-plugin-electron",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "description": "Vite 8 Environment API based plugin for integrating Electron main/preload build",
   "keywords": [
     "electron",
     "vite",
     "vite-plugin"
   ],
-  "homepage": "https://github.com/srymh/vite-plugin-electron/tree/main/packages/vite-plugin-electron#readme",
+  "homepage": "https://srymh.github.io/vite-plugin-electron/",
   "bugs": {
     "url": "https://github.com/srymh/vite-plugin-electron/issues"
   },

--- a/packages/vite-plugin-electron/src/dev.ts
+++ b/packages/vite-plugin-electron/src/dev.ts
@@ -1,4 +1,6 @@
 import { type ChildProcess } from 'node:child_process'
+import { rmSync } from 'node:fs'
+import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { createBuilder, type ViteDevServer } from 'vite'
@@ -45,6 +47,7 @@ type ElectronDevOptions = {
   preloadEntries: ElectronPreloadEntryMap
   debug: ResolvedElectronDebugOptions
   rootDir: string
+  outDirs: string[]
   rendererDevUrl?: string
   rendererDevUrlEnvVar: string
   onRestart: (childProcess: ChildProcess) => void
@@ -184,6 +187,13 @@ async function startElectronDevSession(
   const devServerUrl = resolveDevServerUrl(server, options.rendererDevUrl)
   const hasPreloadEntries = Object.keys(options.preloadEntries).length > 0
   const environmentNames = getElectronWatchEnvironmentNames(hasPreloadEntries)
+
+  // main と preload が同じ outDir を共有する構成では emptyOutDir を無効にしているため、
+  // dev session 開始時に 1 回だけ手動で出力ディレクトリをクリーンし、前回の古い成果物を
+  // 残さないようにする。
+  for (const outDir of options.outDirs) {
+    rmSync(resolve(options.rootDir, outDir), { recursive: true, force: true })
+  }
 
   // 起動済み dev server の resolved config から必要な設定を引き継ぐ。
   // createBuilder は InlineConfig を受け取り、内部で config ファイルを再読み込みするため、

--- a/packages/vite-plugin-electron/src/electron.ts
+++ b/packages/vite-plugin-electron/src/electron.ts
@@ -14,6 +14,7 @@ import {
 } from './environment'
 import {
   createOutDirIgnorePatterns,
+  getUniqueOutDirs,
   resolveElectronPluginOptions,
   validatePackageJsonMainField,
 } from './options'
@@ -186,6 +187,7 @@ export function electron(options: ElectronPluginOptions): Plugin {
         preloadEntries: resolvedOptions.preloadEntries,
         debug: resolvedOptions.debugOptions,
         rootDir: resolvedOptions.rootDir,
+        outDirs: getUniqueOutDirs(resolvedOptions),
         rendererDevUrl: resolvedOptions.rendererOptions.devUrl,
         rendererDevUrlEnvVar: resolvedOptions.rendererOptions.devUrlEnvVar,
         onRestart() {},

--- a/packages/vite-plugin-electron/src/environment.ts
+++ b/packages/vite-plugin-electron/src/environment.ts
@@ -63,13 +63,16 @@ export function createElectronEnvironmentBuildConfig(
   resolvedOptions: ResolvedElectronPluginOptions,
 ): UserConfig {
   const isMain = name === ELECTRON_MAIN_ENVIRONMENT_NAME
+  const hasSharedOutDir =
+    Object.keys(resolvedOptions.preloadEntries).length > 0 &&
+    resolvedOptions.mainOutDir === resolvedOptions.preloadOutDir
 
   const baseConfig: UserConfig = {
     build: {
       outDir: isMain
         ? resolvedOptions.mainOutDir
         : resolvedOptions.preloadOutDir,
-      emptyOutDir: isMain,
+      emptyOutDir: isMain && !hasSharedOutDir,
       copyPublicDir: false,
       emitAssets: false,
       minify: false,
@@ -111,7 +114,9 @@ export function createElectronEnvironmentBuildConfig(
   }
 
   // preload は main が先にクリーンするため、常に emptyOutDir を無効にする。
-  if (!isMain) {
+  // main でも preload と同じ outDir を共有する場合は無効にする（watch リビルド時に
+  // main のクリーンが preload の成果物を巻き添えに削除するのを防ぐ）。
+  if (!isMain || hasSharedOutDir) {
     merged.build.emptyOutDir = false
   }
 

--- a/packages/vite-plugin-electron/src/options.ts
+++ b/packages/vite-plugin-electron/src/options.ts
@@ -467,3 +467,22 @@ export function normalizeGlobPath(filePath: string): string {
     .replace(/^\.?\//, '')
     .replace(/\/$/, '')
 }
+
+/**
+ * dev session 開始時にクリーンすべき出力ディレクトリの一覧を返す。
+ *
+ * main と preload の outDir が同一なら 1 要素、異なれば 2 要素になる。
+ *
+ * @param resolvedOptions 解決済みの plugin オプション
+ * @returns 重複を排除した outDir の配列
+ */
+export function getUniqueOutDirs(
+  resolvedOptions: Pick<
+    ResolvedElectronPluginOptions,
+    'mainOutDir' | 'preloadOutDir'
+  >,
+): string[] {
+  return [
+    ...new Set([resolvedOptions.mainOutDir, resolvedOptions.preloadOutDir]),
+  ]
+}

--- a/packages/vite-plugin-electron/tests/electron.test.ts
+++ b/packages/vite-plugin-electron/tests/electron.test.ts
@@ -23,6 +23,7 @@ import {
   getElectronDebugArgs,
   getElectronSpawnArgs,
   getElectronSpawnEnv,
+  getUniqueOutDirs,
   isProcessStopRequired,
   isSuccessfulWindowsTaskkillExitCode,
   resolveDebugOptions,
@@ -166,6 +167,46 @@ describe('electron plugin', () => {
       entryFileNames: '[name].js',
       format: 'es',
     })
+    expect(config.build?.emptyOutDir).toBe(true)
+  })
+
+  it('main と preload が同じ outDir を共有する場合 main の emptyOutDir は false になる', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: { entry: 'electron/main.ts' },
+          preload: { entry: 'electron/preload.ts' },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    expect(config.build?.emptyOutDir).toBe(false)
+  })
+
+  it('main と preload が異なる outDir なら main の emptyOutDir は true になる', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: {
+            entry: 'electron/main.ts',
+            vite: { build: { outDir: 'dist-electron/main' } },
+          },
+          preload: {
+            entry: 'electron/preload.ts',
+            vite: { build: { outDir: 'dist-electron/preload' } },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
     expect(config.build?.emptyOutDir).toBe(true)
   })
 
@@ -859,5 +900,27 @@ describe('electron plugin', () => {
         validatePackageJsonMainField(tmpDir, mainOutputPath),
       ).toThrow(/見つかりません/)
     })
+  })
+
+  it('同一 outDir なら重複を排除して 1 要素を返す', () => {
+    // Arrange / Act
+    const dirs = getUniqueOutDirs({
+      mainOutDir: 'dist-electron',
+      preloadOutDir: 'dist-electron',
+    })
+
+    // Assert
+    expect(dirs).toEqual(['dist-electron'])
+  })
+
+  it('異なる outDir なら両方を返す', () => {
+    // Arrange / Act
+    const dirs = getUniqueOutDirs({
+      mainOutDir: 'dist-electron/main',
+      preloadOutDir: 'dist-electron/preload',
+    })
+
+    // Assert
+    expect(dirs).toEqual(['dist-electron/main', 'dist-electron/preload'])
   })
 })


### PR DESCRIPTION
## 概要

- main と preload が同じ `outDir` を共有する構成（デフォルト）で、dev の watch リビルド時に main の `emptyOutDir: true` が preload の成果物を巻き添えに削除してしまう不具合を修正する

## 変更内容

- **`environment.ts`**: main と preload が同一 `outDir` を共有する場合、main の `emptyOutDir` も `false` に変更
- **`dev.ts`**: dev session 開始時に `rmSync` で出力ディレクトリを 1 回だけ手動クリーンし、前回の古い成果物が残らないようにする
- **`options.ts`**: `getUniqueOutDirs()` を追加。main/preload の outDir を重複排除して返すユーティリティ
- **`electron.ts`**: `getUniqueOutDirs` を import し、dev options に `outDirs` を渡す
- **`tests/electron.test.ts`**: 4 つのテストケースを追加（共有 outDir 時の `emptyOutDir` 挙動、`getUniqueOutDirs` の重複排除）
- **docs**: `emptyOutDir` の説明を新しい仕様に合わせて更新
- **package.json / `pyproject.toml`**: バージョンを `0.2.0-beta.2` → `0.2.0-beta.3` に更新、homepage URL を GitHub Pages に変更

## 影響範囲

- dev モード（`vite dev`）での Electron ビルドの出力ディレクトリ管理
- main と preload が同一 `outDir` を使うデフォルト構成が主な対象
- main と preload で別々の `outDir` を指定している場合は従来どおり（main 側 `emptyOutDir: true`）

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [x] `pnpm build` でビルドして exe を起動できる

## レビュー観点

- `rmSync(resolve(options.rootDir, outDir), { recursive: true, force: true })` — dev session 開始時にビルド出力ディレクトリを再帰削除する。`outDir` はプラグインが解決した相対パスで、`rootDir` 基準で resolve されるため意図しないパスが削除される可能性は低いが、パスの安全性を確認してほしい
- `hasSharedOutDir` の判定ロジック（`preloadEntries` が存在し、かつ `mainOutDir === preloadOutDir`）が正しいか
- テストケースが十分な境界条件をカバーしているか

## 関連リンク

- #19