### PR TITLE
docs(dev): dev 周辺の JSDoc とコメントを補足

### DIFF
--- a/packages/vite-plugin-electron/src/dev-state.ts
+++ b/packages/vite-plugin-electron/src/dev-state.ts
@@ -83,6 +83,9 @@ export function createElectronBuildCoordinator(
         // restart を返した直後にリセットし、次の watch cycle に備える。
         // BUNDLE_START による個別リセットと合わせて二重に保護する。
         mainReady = false
+        // preload なし構成では待機不要なので true に戻し、main 完了だけで
+        // restart できる状態を維持する。preload あり構成では false にして
+        // 次の cycle で両方の END を待たせる。
         preloadReady = !hasPreloadEntries
         return { type: 'restart' }
       }

--- a/packages/vite-plugin-electron/src/dev.ts
+++ b/packages/vite-plugin-electron/src/dev.ts
@@ -21,7 +21,7 @@ import {
 } from './types'
 
 /**
- * Rollup watch builder が返す watcher のうち、この plugin が利用する最小インターフェース。
+ * Rolldown watch builder が返す watcher のうち、この plugin が利用する最小インターフェース。
  *
  * Vite 側の具体型に強く依存しすぎないよう、必要な `on` と `close` だけに絞っている。
  */
@@ -283,6 +283,14 @@ async function startElectronDevSession(
  *
  * Electron main process はこの URL を環境変数経由で受け取り、renderer を
  * `loadURL` するため、dev 起動前に必ず解決できる必要がある。
+ *
+ * ## `resolvedUrls` の参照タイミングについて
+ *
+ * `server.resolvedUrls` は `httpServer` の `listening` イベント後に設定される。
+ * 現行の Vite 実装ではこの順序が保たれているが、ドキュメントされた保証ではないため、
+ * Vite のメジャーアップデート時に壊れるリスクがある。
+ * 防御策として `resolvedUrls` が null の場合はエラーを投げる。
+ * `rendererDevUrl` を明示指定する external mode ではこのパスを通らないため影響しない。
  *
  * @param server Vite dev server
  * @returns 利用可能な dev server URL

--- a/packages/vite-plugin-electron/src/environment.ts
+++ b/packages/vite-plugin-electron/src/environment.ts
@@ -148,7 +148,7 @@ export function createExternalRendererClientBuildConfig(): UserConfig {
  * build 成立のために client environment 自体は走らせるが、desktop package 側には
  * renderer 資産を残したくないため、最終出力だけを空にする。
  *
- * @param bundle Rollup が書き出し直前に持つ bundle
+ * @param bundle Rolldown が書き出し直前に持つ bundle
  */
 export function removeExternalRendererClientBuildOutputs(
   bundle: Record<string, unknown>,

--- a/packages/vite-plugin-electron/src/types.ts
+++ b/packages/vite-plugin-electron/src/types.ts
@@ -1,7 +1,7 @@
 import type { UserConfig } from 'vite'
 
 /**
- * Rollup watcher から受け取るイベントのうち、この plugin が参照する最小形。
+ * Rolldown watcher から受け取るイベントのうち、この plugin が参照する最小形。
  */
 export type BuildWatcherEvent = {
   code: string


### PR DESCRIPTION
- dev 周辺の内部挙動を説明する JSDoc とコメントを補足
- resolvedUrls の参照タイミングリスクと防御策を resolveDevServerUrl の JSDoc に追記 #7
- build coordinator の preloadReady リセット意図をコメントで明確化 #9
- Rollup 表記を Rolldown に統一