### PR TITLE
fix: Electron 環境で暗黙的な node_modules external 化を無効化

### DIFF
--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -219,6 +219,7 @@ main と preload の両方に適用されるビルド設定の既定値:
 | `sourcemap` | `true` | — |
 | `target` | `'node22'` | — |
 | `external` | `['electron']` | 常に `electron` を externalize |
+| `resolve.noExternal` | `true` | `consumer: 'server'` による暗黙的な node_modules 全 external 化を無効にする |
 | `copyPublicDir` | `false` | — |
 | `emitAssets` | `false` | — |
 | `reportCompressedSize` | `false` | — |

--- a/packages/vite-plugin-electron/src/environment.ts
+++ b/packages/vite-plugin-electron/src/environment.ts
@@ -98,6 +98,13 @@ export function createElectronEnvironmentBuildConfig(
 
   // --- 不変の制約を再適用 ---
 
+  // consumer: 'server' による暗黙的な node_modules 全 external 化を無効にする。
+  // Electron は SSR と異なり asar 内で依存解決が失敗するケースがあるため、
+  // デフォルトではすべての依存をバンドルに含める。
+  // ユーザーが明示的に resolve.noExternal を設定した場合はそちらを尊重する。
+  merged.resolve ??= {}
+  merged.resolve.noExternal ??= true
+
   // rolldownOptions.input は常に plugin が管理する。ユーザーの上書きは無視する。
   merged.build.rolldownOptions.input = isMain
     ? { [resolvedOptions.mainEntryName]: resolvedOptions.mainEntry }

--- a/packages/vite-plugin-electron/tests/electron.test.ts
+++ b/packages/vite-plugin-electron/tests/electron.test.ts
@@ -450,6 +450,81 @@ describe('electron plugin', () => {
     expect(config.build?.target).toBe('node20')
   })
 
+  it('resolve.noExternal がデフォルトで true に設定される', () => {
+    // Arrange
+    const mainConfig = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: { entry: 'electron/main.ts' },
+          preload: { entry: 'electron/preload.ts' },
+        },
+        TEST_CWD,
+      ),
+    )
+    const preloadConfig = createElectronEnvironmentBuildConfig(
+      'electron_preload',
+      resolveElectronPluginOptions(
+        {
+          main: { entry: 'electron/main.ts' },
+          preload: { entry: 'electron/preload.ts' },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    expect(mainConfig.resolve?.noExternal).toBe(true)
+    expect(preloadConfig.resolve?.noExternal).toBe(true)
+  })
+
+  it('vite override で resolve.noExternal を上書きできる', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: {
+            entry: 'electron/main.ts',
+            vite: {
+              resolve: {
+                noExternal: ['some-pkg'],
+              },
+            },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    expect(config.resolve?.noExternal).toEqual(['some-pkg'])
+  })
+
+  it('vite override で resolve.external を指定して特定パッケージだけを外部化できる', () => {
+    // Arrange
+    const config = createElectronEnvironmentBuildConfig(
+      'electron_main',
+      resolveElectronPluginOptions(
+        {
+          main: {
+            entry: 'electron/main.ts',
+            vite: {
+              resolve: {
+                external: ['better-sqlite3'],
+              },
+            },
+          },
+        },
+        TEST_CWD,
+      ),
+    )
+
+    // Assert
+    expect(config.resolve?.external).toEqual(['better-sqlite3'])
+    expect(config.resolve?.noExternal).toBe(true)
+  })
+
   it('mainOutputPath が vite override の outDir と entryFileNames を反映する', () => {
     // Arrange
     const resolved = resolveElectronPluginOptions(


### PR DESCRIPTION
## 概要

- Electron の main/preload ビルドで、`consumer: 'server'` に起因する暗黙的な node_modules 全 external 化を無効化し、依存を既定でバンドル対象にするよう修正しました。
- あわせて既定値のテストを追加し、オプションドキュメントに `resolve.noExternal` の既定値を追記しました。

## 変更内容

- `createElectronEnvironmentBuildConfig` で `resolve.noExternal` の既定値を `true` に設定
- ユーザーが `vite.resolve.noExternal` を明示した場合はその設定を優先する挙動を維持
- `vite.resolve.external` で特定パッケージのみ外部化できることをテストで確認
- オプション一覧に `resolve.noExternal: true` の説明を追加

## 影響範囲

- Electron main/preload のビルド出力に影響します
- これまで暗黙的に external 扱いされていた node_modules 依存が、既定ではバンドルに含まれるようになります
- ビルド成果物のサイズや依存解決の挙動に影響する可能性があります
- 権限/認証/課金/削除/マイグレーションへの影響は差分上は見当たりません
- 設定既定値の変更を含むため、外部化前提の利用者は `resolve.external` または `resolve.noExternal` の明示設定が必要になる場合があります

## 動作確認

- [x] `pnpm test` が成功する
- [x] `pnpm dev` で起動できる
- [x] `pnpm build` でビルドして exe を起動できる

## レビュー観点

- Electron で依存を既定でバンドルする方針が妥当か
- `resolve.noExternal` の既定値変更が既存利用者に与える影響が許容範囲か
- ユーザー指定の `vite.resolve.noExternal` / `vite.resolve.external` が意図どおり優先されるか
- 追加テストで main/preload 両方の既定値変更を十分にカバーできているか

## 関連リンク

- #22 
