### PR TITLE
build: lint と型検査の実行設定を整備

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vite-plugin-electron"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 description = "Vite 8 Environment API based plugin for integrating Electron main/preload build"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:multiple": "pnpm --filter @repo/multi-web build && pnpm --filter @repo/multi-desktop build",
     "preview:multiple": "pnpm build:multiple && pnpm --filter @repo/multi-desktop preview",
     "package:multiple": "pnpm build:multiple && pnpm --filter @repo/multi-desktop package",
+    "lint": "pnpm --filter @srymh/vite-plugin-electron run lint",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check"
   },

--- a/packages/vite-plugin-electron/.oxlintrc.json
+++ b/packages/vite-plugin-electron/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": ["tsdown.config.ts"]
+}

--- a/packages/vite-plugin-electron/package.json
+++ b/packages/vite-plugin-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srymh/vite-plugin-electron",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "description": "Vite 8 Environment API based plugin for integrating Electron main/preload build",
   "keywords": [
     "electron",

--- a/packages/vite-plugin-electron/package.json
+++ b/packages/vite-plugin-electron/package.json
@@ -32,12 +32,13 @@
   },
   "scripts": {
     "build": "pnpm lint && tsdown",
-    "lint": "oxlint",
-    "lint:fix": "oxlint --fix",
+    "lint": "tsgo && oxlint",
+    "lint:fix": "tsgo && oxlint --fix",
     "test": "vitest run"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",
+    "@typescript/native-preview": "7.0.0-dev.20260416.1",
     "oxlint": "^1.57.0",
     "tsdown": "^0.21.4",
     "typescript": "~6.0.2",

--- a/packages/vite-plugin-electron/tsconfig.json
+++ b/packages/vite-plugin-electron/tsconfig.json
@@ -1,22 +1,32 @@
 {
   "compilerOptions": {
+    /* 実行環境 */
     "target": "ES2023",
     "lib": ["ES2023"],
+    "types": ["node"],
+
+    /* モジュール解決 */
     "module": "ESNext",
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
-    "isolatedDeclarations": true,
-    "declaration": true,
     "moduleDetection": "force",
+
+    /* 宣言と出力 */
+    "declaration": true,
+    "isolatedDeclarations": true,
     "noEmit": true,
+
+    /* 厳格な型チェック */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
+
+    /* 相互運用と診断 */
     "skipLibCheck": true,
-    "types": ["node"]
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 17.4.0
       tsdown:
         specifier: ^0.21.4
-        version: 0.21.5(typescript@5.9.3)
+        version: 0.21.5(@typescript/native-preview@7.0.0-dev.20260416.1)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -157,12 +157,15 @@ importers:
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260416.1
+        version: 7.0.0-dev.20260416.1
       oxlint:
         specifier: ^1.57.0
         version: 1.57.0
       tsdown:
         specifier: ^0.21.4
-        version: 0.21.5(typescript@6.0.2)
+        version: 0.21.5(@typescript/native-preview@7.0.0-dev.20260416.1)(typescript@6.0.2)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
@@ -1000,6 +1003,45 @@ packages:
   '@typescript-eslint/visitor-keys@8.57.2':
     resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-C+apBESKbPP2WiWkQH9z14UErEB7hbSLisxx7CdHEwjt80cN7Xh09qcFPe+b8ouMtsVNVNAQUYpZyCI5+/6Y9A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-TKHD0tNPcm1vrpEf5yun3VqrNTDTM3KYBj6Ize305CgFuGdtVLGWPJQ4DobUUliR68RzrnDRTt+u1nc70hcEHg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-wxsJYr+UXzEevoktqhLa8slPTuMeFn/zROkiT6BcagWkM/H+/dxEFHOhM4HNgAemTJOp4cGyxXSRNHswgiUWsg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-EKchoSx8/Gv3HgsTgSSK5FU5ODZQ6hd+qxdgc5c9QTS+2WSN5UX54wCz7wjipHMrTq4mGnqXLfgVSl2JlGY1TA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-ey6Gvb5OqaOVxx8Ur5LVAbe07VEwyoFkb6v9zlN9Q/lR0DeJB/sFVZ53CIDuded5KG+zbLcGVJXLn3HDJQmzXA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-JrxGuXGthBtKt3kc987XQDhorn+XXCXffbd/a9rc1XZ8koOhS/rZAnLv7dHx7m9DLtUXAPPpe+3vu25WfPfuzg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-Ht04G9kt0fopDA0cB1Ng7/X6SScRIXaKZk9m/guyesuRlt3el+9eefF6YrnYCczzKlmZ4doPbR/xXiKFSnZA6Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260416.1':
+    resolution: {integrity: sha512-DcmbOGc6m0YufnSdXb8OIfyl7J1MrjSy2Sz1vqe9xVw3/o+i3d/H46oOlGiEdVmFDhV4+xFTyd/OpJ3XK2+wrQ==}
+    hasBin: true
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -2024,6 +2066,9 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -3702,6 +3747,37 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260416.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260416.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260416.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260416.1
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.3(@types/node@24.12.0)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -4236,7 +4312,7 @@ snapshots:
       '@electron/asar': 3.4.1
       debug: 4.4.3
       fs-extra: 7.0.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       temp: 0.9.4
     optionalDependencies:
       '@electron/windows-sign': 1.2.2
@@ -4806,6 +4882,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
@@ -5195,7 +5273,7 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.5(@typescript/native-preview@7.0.0-dev.20260416.1)(rolldown@1.0.0-rc.11)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -5208,11 +5286,12 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.11
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260416.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.11)(typescript@6.0.2):
+  rolldown-plugin-dts@0.22.5(@typescript/native-preview@7.0.0-dev.20260416.1)(rolldown@1.0.0-rc.11)(typescript@6.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -5225,6 +5304,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.11
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260416.1
       typescript: 6.0.2
     transitivePeerDependencies:
       - oxc-resolver
@@ -5454,7 +5534,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tsdown@0.21.5(typescript@5.9.3):
+  tsdown@0.21.5(@typescript/native-preview@7.0.0-dev.20260416.1)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -5465,7 +5545,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.11
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.5(@typescript/native-preview@7.0.0-dev.20260416.1)(rolldown@1.0.0-rc.11)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -5481,7 +5561,7 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.21.5(typescript@6.0.2):
+  tsdown@0.21.5(@typescript/native-preview@7.0.0-dev.20260416.1)(typescript@6.0.2):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -5492,7 +5572,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.11
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.11)(typescript@6.0.2)
+      rolldown-plugin-dts: 0.22.5(@typescript/native-preview@7.0.0-dev.20260416.1)(rolldown@1.0.0-rc.11)(typescript@6.0.2)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15


### PR DESCRIPTION
## 概要

- vite-plugin-electron の lint と型検査の実行設定を整備し、関連パッケージのバージョンを 0.2.0-beta.4 に更新します。

## 変更内容

- ルートの scripts に vite-plugin-electron 向けの lint コマンドを追加しました。
- vite-plugin-electron の lint と lint:fix で tsgo を実行するように変更し、@typescript/native-preview を開発依存へ追加しました。
- oxlint 設定ファイルを追加し、tsdown.config.ts を lint 対象外にしました。
- tsconfig の compilerOptions を整理し、forceConsistentCasingInFileNames を有効化しました。
- パッケージ本体と docs のバージョン表記を 0.2.0-beta.4 に更新し、lockfile を同期しました。
- テストファイルの追加・変更はありません。

## 影響範囲

- 設定変更あり: vite-plugin-electron パッケージの lint 実行手順が tsgo 前提に変わり、開発環境で @typescript/native-preview が必要になります。
- プラグインの src 実装には差分がないため、ランタイム挙動への直接変更は差分上ありません。
- docs の pyproject にあるバージョン表記も 0.2.0-beta.4 に更新されます。

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm dev で起動できる
- [x] pnpm build でビルドして .app / .exe を起動できる

## レビュー観点

- tsgo と @typescript/native-preview の追加がローカル環境で問題なく動作するか確認してください。
- tsdown.config.ts を oxlint 対象外にする設定が意図どおりの lint 範囲になっているか確認してください。
- 0.2.0-beta.4 へのバージョン更新対象が packages と docs で揃っているか確認してください。

## 関連リンク

- なし