### PR TITLE
feat(renderer): external renderer の起動待機設定を追加

### DIFF
--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -167,10 +167,20 @@ debug が有効な場合、Electron 起動時に次が付与されます。
 ```ts
 type ElectronRendererMode = 'internal' | 'external'
 
+type ElectronRendererWaitForReadyMode = 'auto' | 'always' | 'off'
+
+type ElectronRendererWaitForReadyOptions = {
+  mode?: ElectronRendererWaitForReadyMode
+  timeoutMs?: number
+  intervalMs?: number
+  requestTimeoutMs?: number
+}
+
 type ElectronRendererOptions = {
   mode?: ElectronRendererMode
   devUrl?: string
   devUrlEnvVar?: string
+  waitForReady?: ElectronRendererWaitForReadyOptions
 }
 ```
 
@@ -179,6 +189,7 @@ type ElectronRendererOptions = {
 | `mode` | `ElectronRendererMode` | 自動推論 | renderer の配置方式 |
 | `devUrl` | `string` | — | 外部 renderer dev server の URL |
 | `devUrlEnvVar` | `string` | `'VITE_DEV_SERVER_URL'` | Electron main へ URL を渡す環境変数名 |
+| `waitForReady` | `ElectronRendererWaitForReadyOptions` | auto | external mode の起動待機設定 |
 
 ### mode の自動推論
 
@@ -195,6 +206,23 @@ type ElectronRendererOptions = {
 
 外部の renderer dev server URL を `devUrl` で指定します。desktop package 側に `index.html` を置く必要はありません。プラグインが `appType: 'custom'` と空の仮想 client entry を使ってビルドを成立させます。
 
+`waitForReady` を省略した場合でも、loopback の `http` / `https` URL では `mode: 'auto'` が有効になり、renderer dev server が応答可能になるまで Electron の初回起動と restart を待機します。タイムアウト時は Electron を起動せず、dev ログへエラーを出します。
+
+### `waitForReady`
+
+| フィールド | 型 | 既定値 | 説明 |
+|---|---|---|---|
+| `mode` | `ElectronRendererWaitForReadyMode` | `'auto'` | 待機対象の判定方式 |
+| `timeoutMs` | `number` | `30000` | 起動を諦めるまでの総待機時間 |
+| `intervalMs` | `number` | `500` | polling の間隔 |
+| `requestTimeoutMs` | `number` | `5000` | 単一リクエストのタイムアウト |
+
+- `auto`: external mode かつ loopback の `http` / `https` URL (`localhost`, `127.0.0.1`, `::1`) のときだけ待機します。
+- `always`: external mode の `http` / `https` URL なら host に関係なく待機します。
+- `off`: 起動待機を無効にします。
+
+到達確認は `HEAD` 優先で行い、405 / 501 のように `HEAD` 非対応なサーバーには `GET` へフォールバックします。
+
 ```ts
 electron({
   main: { entry: 'src/main.ts' },
@@ -202,6 +230,10 @@ electron({
     mode: 'external',
     devUrl: 'http://localhost:5173',
     devUrlEnvVar: 'ELECTRON_RENDERER_URL',
+    waitForReady: {
+      mode: 'auto',
+      timeoutMs: 30_000,
+    },
   },
 })
 ```

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vite-plugin-electron"
-version = "0.2.0-beta.4"
+version = "0.2.0-beta.5"
 description = "Vite 8 Environment API based plugin for integrating Electron main/preload build"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/vite-plugin-electron/README.md
+++ b/packages/vite-plugin-electron/README.md
@@ -84,6 +84,9 @@ Preload entries output as CJS (`.cjs`). Main outputs as ESM (`.js`).
 | `mode` | `'internal' \| 'external'` | auto | Renderer placement mode |
 | `devUrl` | `string` | — | External renderer dev server URL |
 | `devUrlEnvVar` | `string` | `'VITE_DEV_SERVER_URL'` | Env var name for the renderer URL |
+| `waitForReady` | `ElectronRendererWaitForReadyOptions` | auto | Wait policy before launching Electron in external mode |
+
+`waitForReady` uses `mode: 'auto' | 'always' | 'off'` with optional `timeoutMs`, `intervalMs`, and `requestTimeoutMs`. In `auto`, the plugin waits only for loopback `http`/`https` renderer URLs such as `localhost`, `127.0.0.1`, and `::1`. If the timeout is reached, Electron is not spawned and the dev session logs an error.
 
 For full option details including preload entry formats, constraints, and build defaults, see the [options reference](../../docs/docs/options.md).
 
@@ -101,12 +104,14 @@ import {
   type ElectronDebugOptions,
   type ElectronRendererMode,
   type ElectronRendererOptions,
+  type ElectronRendererWaitForReadyMode,
+  type ElectronRendererWaitForReadyOptions,
 } from '@srymh/vite-plugin-electron'
 ```
 
 ## Build / Dev Behavior
 
-**`vite dev`**: Starts the renderer dev server, watch-builds `electron_main` (and `electron_preload` if configured), and restarts Electron when builds complete. Restart requests are coalesced by an internal scheduler to avoid unnecessary restarts.
+**`vite dev`**: Starts the renderer dev server, watch-builds `electron_main` (and `electron_preload` if configured), and restarts Electron when builds complete. In external mode, Electron can wait for the configured renderer URL before the initial launch and each restart. Restart requests are coalesced by an internal scheduler to avoid unnecessary restarts.
 
 **`vite build`**: Builds client, `electron_main`, and `electron_preload` environments. The plugin automatically enables `builder: {}`, so `vite build --app` is not required in user scripts.
 

--- a/packages/vite-plugin-electron/README_ja.md
+++ b/packages/vite-plugin-electron/README_ja.md
@@ -84,6 +84,9 @@ preload は CJS（`.cjs`）で出力されます。main は ESM（`.js`）。
 | `mode` | `'internal' \| 'external'` | 自動推論 | renderer の配置方式 |
 | `devUrl` | `string` | — | 外部 renderer dev server の URL |
 | `devUrlEnvVar` | `string` | `'VITE_DEV_SERVER_URL'` | renderer URL を渡す環境変数名 |
+| `waitForReady` | `ElectronRendererWaitForReadyOptions` | auto | external mode で Electron 起動前に待機する設定 |
+
+`waitForReady` では `mode: 'auto' | 'always' | 'off'` と、必要に応じて `timeoutMs`、`intervalMs`、`requestTimeoutMs` を指定できます。`auto` では `localhost`、`127.0.0.1`、`::1` のような loopback の `http`/`https` URL だけを待機対象にします。タイムアウト時は Electron を起動せず、dev ログにエラーを出します。
 
 preload entry の書式、制約、ビルド既定値の詳細は [オプション詳細](../../docs/docs/options.md) を参照してください。
 
@@ -101,12 +104,14 @@ import {
   type ElectronDebugOptions,
   type ElectronRendererMode,
   type ElectronRendererOptions,
+  type ElectronRendererWaitForReadyMode,
+  type ElectronRendererWaitForReadyOptions,
 } from '@srymh/vite-plugin-electron'
 ```
 
 ## ビルド / 開発の動作
 
-**`vite dev`**: renderer dev server の起動、`electron_main`（と `electron_preload`）の watch build、build 完了時の Electron 再起動を行います。内部 scheduler が短時間の複数回 build を coalesce し、不要な再起動を抑制します。
+**`vite dev`**: renderer dev server の起動、`electron_main`（と `electron_preload`）の watch build、build 完了時の Electron 再起動を行います。external mode では、初回起動と各 restart の前に設定された renderer URL の到達待ちを入れられます。内部 scheduler が短時間の複数回 build を coalesce し、不要な再起動を抑制します。
 
 **`vite build`**: client、`electron_main`、`electron_preload` environment をビルドします。`builder: {}` を自動で有効化するため、`vite build --app` は不要です。
 

--- a/packages/vite-plugin-electron/package.json
+++ b/packages/vite-plugin-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srymh/vite-plugin-electron",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "description": "Vite 8 Environment API based plugin for integrating Electron main/preload build",
   "keywords": [
     "electron",

--- a/packages/vite-plugin-electron/src/dev.ts
+++ b/packages/vite-plugin-electron/src/dev.ts
@@ -18,6 +18,7 @@ import {
   type ElectronEnvironmentName,
   type ElectronPreloadEntryMap,
   type ResolvedElectronDebugOptions,
+  type ResolvedElectronRendererWaitForReadyOptions,
 } from './types'
 
 /**
@@ -48,8 +49,10 @@ type ElectronDevOptions = {
   debug: ResolvedElectronDebugOptions
   rootDir: string
   outDirs: string[]
+  rendererMode: 'internal' | 'external'
   rendererDevUrl?: string
   rendererDevUrlEnvVar: string
+  rendererWaitForReady: ResolvedElectronRendererWaitForReadyOptions
   onRestart: (childProcess: ChildProcess) => void
 }
 
@@ -244,8 +247,10 @@ async function startElectronDevSession(
           {
             debug: options.debug,
             rootDir: options.rootDir,
+            rendererMode: options.rendererMode,
             devServerUrl,
             devServerUrlEnvVar: options.rendererDevUrlEnvVar,
+            rendererWaitForReady: options.rendererWaitForReady,
           },
         )
 

--- a/packages/vite-plugin-electron/src/electron.ts
+++ b/packages/vite-plugin-electron/src/electron.ts
@@ -34,6 +34,8 @@ export type {
   ElectronPreloadOptions,
   ElectronRendererMode,
   ElectronRendererOptions,
+  ElectronRendererWaitForReadyMode,
+  ElectronRendererWaitForReadyOptions,
 } from './types'
 
 /**
@@ -188,8 +190,10 @@ export function electron(options: ElectronPluginOptions): Plugin {
         debug: resolvedOptions.debugOptions,
         rootDir: resolvedOptions.rootDir,
         outDirs: getUniqueOutDirs(resolvedOptions),
+        rendererMode: resolvedOptions.rendererOptions.mode,
         rendererDevUrl: resolvedOptions.rendererOptions.devUrl,
         rendererDevUrlEnvVar: resolvedOptions.rendererOptions.devUrlEnvVar,
+        rendererWaitForReady: resolvedOptions.rendererOptions.waitForReady,
         onRestart() {},
       })
     },

--- a/packages/vite-plugin-electron/src/index.ts
+++ b/packages/vite-plugin-electron/src/index.ts
@@ -10,4 +10,6 @@ export type {
   ElectronPreloadOptions,
   ElectronRendererMode,
   ElectronRendererOptions,
+  ElectronRendererWaitForReadyMode,
+  ElectronRendererWaitForReadyOptions,
 } from './electron'

--- a/packages/vite-plugin-electron/src/options.ts
+++ b/packages/vite-plugin-electron/src/options.ts
@@ -8,10 +8,18 @@ import {
   type ElectronPluginOptions,
   type ElectronPreloadEntryMap,
   type ElectronPreloadInput,
+  type ElectronRendererOptions,
+  type ElectronRendererMode,
+  type ElectronRendererWaitForReadyMode,
   type ResolvedElectronDebugOptions,
   type ResolvedElectronPluginOptions,
   type ResolvedElectronRendererOptions,
+  type ResolvedElectronRendererWaitForReadyOptions,
 } from './types'
+
+const DEFAULT_RENDERER_WAIT_FOR_READY_TIMEOUT_MS = 30_000
+const DEFAULT_RENDERER_WAIT_FOR_READY_INTERVAL_MS = 500
+const DEFAULT_RENDERER_WAIT_FOR_READY_REQUEST_TIMEOUT_MS = 5_000
 
 /**
  * 利用者オプションを plugin 実行に必要な内部表現へ正規化する。
@@ -121,7 +129,101 @@ export function resolveRendererOptions(
     devUrl: renderer?.devUrl,
     devUrlEnvVar:
       renderer?.devUrlEnvVar ?? DEFAULT_RENDERER_DEV_SERVER_URL_ENV_VAR,
+    waitForReady: resolveRendererWaitForReadyOptions(renderer?.waitForReady),
   }
+}
+
+/**
+ * renderer dev server の到達待ち設定へ既定値を適用する。
+ *
+ * @param waitForReady 利用者が指定した待機設定
+ * @returns すべてのフィールドが具体化された待機設定
+ */
+export function resolveRendererWaitForReadyOptions(
+  waitForReady: ElectronRendererOptions['waitForReady'],
+): ResolvedElectronRendererWaitForReadyOptions {
+  return {
+    mode: waitForReady?.mode ?? 'auto',
+    timeoutMs:
+      waitForReady?.timeoutMs ?? DEFAULT_RENDERER_WAIT_FOR_READY_TIMEOUT_MS,
+    intervalMs:
+      waitForReady?.intervalMs ?? DEFAULT_RENDERER_WAIT_FOR_READY_INTERVAL_MS,
+    requestTimeoutMs:
+      waitForReady?.requestTimeoutMs ??
+      DEFAULT_RENDERER_WAIT_FOR_READY_REQUEST_TIMEOUT_MS,
+  }
+}
+
+/**
+ * 与えられた renderer URL に対して起動待機を挟むべきか判定する。
+ *
+ * `always` は external + http/https URL なら常に待機する。`auto` は loopback
+ * host のときだけ待機し、`off` は常に待機しない。
+ *
+ * @param rendererMode renderer の配置方式
+ * @param devServerUrl 判定対象の renderer dev server URL
+ * @param waitMode 解決済みの待機モード
+ * @returns spawn 前に待機すべきなら `true`
+ */
+export function shouldWaitForRendererReady(
+  rendererMode: ElectronRendererMode,
+  devServerUrl: string,
+  waitMode: ElectronRendererWaitForReadyMode,
+): boolean {
+  if (rendererMode !== 'external' || waitMode === 'off') {
+    return false
+  }
+
+  const rendererUrl = safeParseUrl(devServerUrl)
+
+  if (!rendererUrl || !isHttpRendererUrl(rendererUrl)) {
+    return false
+  }
+
+  if (waitMode === 'always') {
+    return true
+  }
+
+  return isLoopbackHostname(rendererUrl.hostname)
+}
+
+/**
+ * renderer dev server URL を安全に parse する。
+ *
+ * @param devServerUrl parse 対象の URL 文字列
+ * @returns parse 成功時は URL、失敗時は `undefined`
+ */
+function safeParseUrl(devServerUrl: string): URL | undefined {
+  try {
+    return new URL(devServerUrl)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * renderer URL が HTTP(S) か判定する。
+ *
+ * @param rendererUrl 判定対象の URL
+ * @returns `http:` または `https:` なら `true`
+ */
+function isHttpRendererUrl(rendererUrl: URL): boolean {
+  return rendererUrl.protocol === 'http:' || rendererUrl.protocol === 'https:'
+}
+
+/**
+ * hostname が loopback 宛てか判定する。
+ *
+ * @param hostname 判定対象の hostname
+ * @returns localhost、127.0.0.1、::1 のいずれかなら `true`
+ */
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]'
+  )
 }
 
 /**

--- a/packages/vite-plugin-electron/src/process.ts
+++ b/packages/vite-plugin-electron/src/process.ts
@@ -7,8 +7,14 @@ import {
   getElectronSpawnEnv,
   isProcessStopRequired,
   isSuccessfulWindowsTaskkillExitCode,
+  shouldWaitForRendererReady,
 } from './options'
-import { type ResolvedElectronDebugOptions } from './types'
+import { waitForRendererReady } from './renderer-ready'
+import {
+  type ElectronRendererMode,
+  type ResolvedElectronDebugOptions,
+  type ResolvedElectronRendererWaitForReadyOptions,
+} from './types'
 
 /**
  * Electron child process の起動に必要な入力。
@@ -19,8 +25,10 @@ import { type ResolvedElectronDebugOptions } from './types'
 type LaunchElectronProcessOptions = {
   debug: ResolvedElectronDebugOptions
   rootDir: string
+  rendererMode: ElectronRendererMode
   devServerUrl: string
   devServerUrlEnvVar: string
+  rendererWaitForReady: ResolvedElectronRendererWaitForReadyOptions
 }
 
 /** SIGTERM 送信後に SIGKILL へ昇格するまでの待ち時間 (ms)。 */
@@ -33,7 +41,6 @@ const SIGKILL_TIMEOUT_MS = 3_000
 const TASKKILL_TIMEOUT_MS = 10_000
 
 const require = createRequire(import.meta.url)
-const electronBinary = require('electron')
 
 /**
  * 既存の Electron process を停止し、新しい process を起動する。
@@ -50,7 +57,7 @@ export async function restartElectronProcess(
   options: LaunchElectronProcessOptions,
 ): Promise<ChildProcess> {
   await stopElectronProcess(currentElectronProcess)
-  return launchElectronProcess(options)
+  return await launchElectronProcess(options)
 }
 
 /**
@@ -67,10 +74,24 @@ export async function restartElectronProcess(
  * @param options 起動設定
  * @returns 起動した child process
  */
-export function launchElectronProcess(
+export async function launchElectronProcess(
   options: LaunchElectronProcessOptions,
-): ChildProcess {
+): Promise<ChildProcess> {
+  if (
+    shouldWaitForRendererReady(
+      options.rendererMode,
+      options.devServerUrl,
+      options.rendererWaitForReady.mode,
+    )
+  ) {
+    await waitForRendererReady(
+      options.devServerUrl,
+      options.rendererWaitForReady,
+    )
+  }
+
   const electronArgs = getElectronSpawnArgs(options.debug, options.rootDir)
+  const electronBinary = getElectronBinary()
 
   if (options.debug.enabled) {
     console.log(
@@ -85,6 +106,18 @@ export function launchElectronProcess(
     env: getElectronSpawnEnv(options.devServerUrl, options.devServerUrlEnvVar),
     detached: !isWindows,
   })
+}
+
+/**
+ * Electron executable の解決を必要時まで遅延する。
+ *
+ * waitForRendererReady のような pure helper を import するだけのテストで Electron 本体を
+ * 解決しないようにし、module import 時の副作用を最小化する。
+ *
+ * @returns 現在の環境で利用する Electron executable path
+ */
+function getElectronBinary(): string {
+  return require('electron') as string
 }
 
 /**

--- a/packages/vite-plugin-electron/src/renderer-ready.ts
+++ b/packages/vite-plugin-electron/src/renderer-ready.ts
@@ -1,0 +1,135 @@
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { type ResolvedElectronRendererWaitForReadyOptions } from './types'
+
+type WaitForRendererReadyDependencies = {
+  fetchImpl?: typeof globalThis.fetch
+  now?: () => number
+  sleep?: (delayMs: number) => Promise<void>
+}
+
+/**
+ * renderer dev server が HTTP 応答可能になるまで一定間隔で待機する。
+ *
+ * `HEAD` が 405 / 501 を返すサーバーには `GET` へフォールバックし、ネットワーク的に
+ * 応答が返れば ready とみなす。接続拒否やタイムアウトが続き、指定時間を超えた場合は
+ * Electron を起動せずエラーにする。
+ *
+ * @param devServerUrl 待機対象の renderer dev server URL
+ * @param options 解決済みの待機設定
+ * @param dependencies テスト用に差し替え可能な依存関係
+ * @returns 到達確認できたら解決する Promise
+ * @throws renderer がタイムアウトまで応答しない場合
+ */
+export async function waitForRendererReady(
+  devServerUrl: string,
+  options: ResolvedElectronRendererWaitForReadyOptions,
+  dependencies: WaitForRendererReadyDependencies = {},
+): Promise<void> {
+  const fetchImpl = dependencies.fetchImpl ?? globalThis.fetch
+  const now = dependencies.now ?? Date.now
+  const sleep = dependencies.sleep ?? defaultSleep
+  const startedAt = now()
+
+  while (true) {
+    if (
+      await probeRendererReady(
+        fetchImpl,
+        devServerUrl,
+        options.requestTimeoutMs,
+      )
+    ) {
+      return
+    }
+
+    if (now() - startedAt >= options.timeoutMs) {
+      throw new Error(
+        `[vite-plugin-electron] Renderer URL "${devServerUrl}" did not respond within ${options.timeoutMs}ms. Electron launch was skipped.`,
+      )
+    }
+
+    await sleep(options.intervalMs)
+  }
+}
+
+/**
+ * renderer dev server へ到達確認用の HTTP リクエストを送る。
+ *
+ * @param fetchImpl 実際に HTTP リクエストを行う関数
+ * @param devServerUrl 待機対象の URL
+ * @param requestTimeoutMs 個別リクエストのタイムアウト
+ * @returns 応答が返れば `true`、接続失敗なら `false`
+ */
+async function probeRendererReady(
+  fetchImpl: typeof globalThis.fetch,
+  devServerUrl: string,
+  requestTimeoutMs: number,
+): Promise<boolean> {
+  const headResponse = await requestRendererReady(
+    fetchImpl,
+    devServerUrl,
+    'HEAD',
+    requestTimeoutMs,
+  )
+
+  if (headResponse === 'ready') {
+    return true
+  }
+
+  if (headResponse === 'fallback') {
+    return (
+      (await requestRendererReady(
+        fetchImpl,
+        devServerUrl,
+        'GET',
+        requestTimeoutMs,
+      )) === 'ready'
+    )
+  }
+
+  return false
+}
+
+/**
+ * 単一の HTTP リクエストを送って ready 判定を返す。
+ *
+ * @param fetchImpl 実際に HTTP リクエストを行う関数
+ * @param devServerUrl 待機対象の URL
+ * @param method 使用する HTTP メソッド
+ * @param requestTimeoutMs 個別リクエストのタイムアウト
+ * @returns ready / fallback / false の判定結果
+ */
+async function requestRendererReady(
+  fetchImpl: typeof globalThis.fetch,
+  devServerUrl: string,
+  method: 'GET' | 'HEAD',
+  requestTimeoutMs: number,
+): Promise<'ready' | 'fallback' | false> {
+  try {
+    const response = await fetchImpl(devServerUrl, {
+      method,
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    })
+
+    if (
+      method === 'HEAD' &&
+      (response.status === 405 || response.status === 501)
+    ) {
+      return 'fallback'
+    }
+
+    return 'ready'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 次の polling まで非同期待機する。
+ *
+ * @param delayMs 待機時間
+ * @returns 指定時間経過後に解決する Promise
+ */
+async function defaultSleep(delayMs: number): Promise<void> {
+  await delay(delayMs)
+}

--- a/packages/vite-plugin-electron/src/types.ts
+++ b/packages/vite-plugin-electron/src/types.ts
@@ -34,11 +34,23 @@ export type ElectronDebugOptions = {
 /** renderer の配置方式を表す公開設定。 */
 export type ElectronRendererMode = 'internal' | 'external'
 
+/** renderer dev server の到達待ち方式を表す公開設定。 */
+export type ElectronRendererWaitForReadyMode = 'auto' | 'always' | 'off'
+
+/** external renderer の起動待ちを制御する公開設定。 */
+export type ElectronRendererWaitForReadyOptions = {
+  mode?: ElectronRendererWaitForReadyMode
+  timeoutMs?: number
+  intervalMs?: number
+  requestTimeoutMs?: number
+}
+
 /** Electron main が参照する renderer の場所を制御する公開設定。 */
 export type ElectronRendererOptions = {
   mode?: ElectronRendererMode
   devUrl?: string
   devUrlEnvVar?: string
+  waitForReady?: ElectronRendererWaitForReadyOptions
 }
 
 /** preload entry 名から source path を引く正規化済み map。 */
@@ -100,10 +112,19 @@ export type ResolvedElectronDebugOptions = {
 }
 
 /** 内部で常に具体値へ解決した renderer 設定。 */
+export type ResolvedElectronRendererWaitForReadyOptions = {
+  mode: ElectronRendererWaitForReadyMode
+  timeoutMs: number
+  intervalMs: number
+  requestTimeoutMs: number
+}
+
+/** 内部で常に具体値へ解決した renderer 設定。 */
 export type ResolvedElectronRendererOptions = {
   mode: ElectronRendererMode
   devUrl?: string
   devUrlEnvVar: string
+  waitForReady: ResolvedElectronRendererWaitForReadyOptions
 }
 
 /**

--- a/packages/vite-plugin-electron/tests/electron.test.ts
+++ b/packages/vite-plugin-electron/tests/electron.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   createElectronBuildCoordinator,
@@ -29,8 +29,11 @@ import {
   resolveDebugOptions,
   resolveElectronPluginOptions,
   resolveRendererOptions,
+  resolveRendererWaitForReadyOptions,
+  shouldWaitForRendererReady,
   validatePackageJsonMainField,
 } from '../src/options'
+import { waitForRendererReady } from '../src/renderer-ready'
 
 /** OS 間でパス区切りを揃える正規化ヘルパー */
 function p(s: string): string {
@@ -607,6 +610,12 @@ describe('electron plugin', () => {
       mode: 'external',
       devUrl: 'http://localhost:4173',
       devUrlEnvVar: 'ELECTRON_RENDERER_URL',
+      waitForReady: {
+        mode: 'auto',
+        timeoutMs: 30_000,
+        intervalMs: 500,
+        requestTimeoutMs: 5_000,
+      },
     })
     expect(
       getElectronSpawnEnv('http://localhost:4173', 'ELECTRON_RENDERER_URL', {
@@ -624,6 +633,12 @@ describe('electron plugin', () => {
       mode: 'internal',
       devUrl: undefined,
       devUrlEnvVar: 'VITE_DEV_SERVER_URL',
+      waitForReady: {
+        mode: 'auto',
+        timeoutMs: 30_000,
+        intervalMs: 500,
+        requestTimeoutMs: 5_000,
+      },
     })
     expect(
       resolveRendererOptions({
@@ -633,7 +648,166 @@ describe('electron plugin', () => {
       mode: 'external',
       devUrl: 'http://localhost:4173',
       devUrlEnvVar: 'VITE_DEV_SERVER_URL',
+      waitForReady: {
+        mode: 'auto',
+        timeoutMs: 30_000,
+        intervalMs: 500,
+        requestTimeoutMs: 5_000,
+      },
     })
+  })
+
+  it('renderer の waitForReady 設定へ既定値を適用する', () => {
+    // Arrange
+    const waitForReady = {
+      intervalMs: 250,
+    }
+
+    // Act
+    const resolved = resolveRendererWaitForReadyOptions(waitForReady)
+
+    // Assert
+    expect(resolved).toEqual({
+      mode: 'auto',
+      timeoutMs: 30_000,
+      intervalMs: 250,
+      requestTimeoutMs: 5_000,
+    })
+  })
+
+  it('auto モードでは loopback の external renderer URL だけ待機する', () => {
+    // Arrange / Act / Assert
+    expect(
+      shouldWaitForRendererReady('external', 'http://localhost:4173', 'auto'),
+    ).toBe(true)
+    expect(
+      shouldWaitForRendererReady('external', 'https://127.0.0.1:4173', 'auto'),
+    ).toBe(true)
+    expect(
+      shouldWaitForRendererReady('external', 'http://[::1]:4173', 'auto'),
+    ).toBe(true)
+    expect(
+      shouldWaitForRendererReady('external', 'https://example.com', 'auto'),
+    ).toBe(false)
+    expect(
+      shouldWaitForRendererReady('external', 'file:///tmp/index.html', 'auto'),
+    ).toBe(false)
+    expect(
+      shouldWaitForRendererReady('internal', 'http://localhost:4173', 'auto'),
+    ).toBe(false)
+  })
+
+  it('always と off で renderer 待機の有無を明示できる', () => {
+    // Arrange / Act / Assert
+    expect(
+      shouldWaitForRendererReady('external', 'https://example.com', 'always'),
+    ).toBe(true)
+    expect(
+      shouldWaitForRendererReady('external', 'custom://renderer', 'always'),
+    ).toBe(false)
+    expect(
+      shouldWaitForRendererReady('external', 'http://localhost:4173', 'off'),
+    ).toBe(false)
+  })
+
+  it('renderer dev server が応答すれば待機を終了する', async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    const sleep = vi.fn(async () => {})
+
+    // Act
+    await waitForRendererReady(
+      'http://localhost:4173',
+      {
+        mode: 'auto',
+        timeoutMs: 30_000,
+        intervalMs: 500,
+        requestTimeoutMs: 5_000,
+      },
+      {
+        fetchImpl,
+        sleep,
+        now: () => 0,
+      },
+    )
+
+    // Assert
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:4173',
+      expect.objectContaining({ method: 'HEAD' }),
+    )
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('HEAD 非対応の renderer dev server には GET でフォールバックする', async () => {
+    // Arrange
+    const fetchImpl = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 405 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    // Act
+    await waitForRendererReady(
+      'http://localhost:4173',
+      {
+        mode: 'auto',
+        timeoutMs: 30_000,
+        intervalMs: 500,
+        requestTimeoutMs: 5_000,
+      },
+      {
+        fetchImpl,
+        sleep: async () => {},
+        now: () => 0,
+      },
+    )
+
+    // Assert
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:4173',
+      expect.objectContaining({ method: 'HEAD' }),
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4173',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
+  it('renderer dev server が応答しなければタイムアウトで失敗する', async () => {
+    // Arrange
+    let currentTime = 0
+    const fetchImpl = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValue(new TypeError('connect ECONNREFUSED'))
+    const sleep = vi.fn(async (delayMs: number) => {
+      currentTime += delayMs
+    })
+
+    // Act / Assert
+    await expect(
+      waitForRendererReady(
+        'http://localhost:4173',
+        {
+          mode: 'auto',
+          timeoutMs: 1_000,
+          intervalMs: 500,
+          requestTimeoutMs: 100,
+        },
+        {
+          fetchImpl,
+          sleep,
+          now: () => currentTime,
+        },
+      ),
+    ).rejects.toThrow(
+      '[vite-plugin-electron] Renderer URL "http://localhost:4173" did not respond within 1000ms. Electron launch was skipped.',
+    )
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 
   it('external renderer mode 用に client build を空 entry へ差し替える', () => {


### PR DESCRIPTION
## 概要

- external renderer 利用時に、Electron の初回起動と再起動の前に renderer dev server の応答待機を入れられるようにしました。
- 既定値は auto とし、loopback の http/https URL のみ自動待機します。always と off で明示制御もできます。

## 変更内容

- renderer.waitForReady オプションと関連公開型を追加し、timeoutMs、intervalMs、requestTimeoutMs を指定できるようにしました。
- 起動待機ロジックを追加し、HEAD で疎通確認しつつ 405 / 501 の場合は GET にフォールバックするようにしました。
- Electron 起動処理を非同期化し、待機判定後に Electron バイナリを遅延解決するようにしました。
- README、README_ja、options ドキュメントを更新し、バージョンを 0.2.0-beta.5 に更新しました。
- waitForReady の既定値適用、待機条件、フォールバック、タイムアウト失敗をカバーするテストを追加しました。

## 影響範囲

- external mode の開発時起動フローが変わり、renderer dev server 未起動時は Electron を起動せずエラー終了します。
- 公開 API として renderer.waitForReady 関連の設定と型が追加されるため、利用者向け設定と型定義に影響します。
- internal mode と build 時のフローには、差分上は直接の変更はありません。

## 動作確認

- [x] pnpm test が成功する
- [x] pnpm dev で起動できる
- [x] pnpm build でビルドして .app/.exe を起動できる

## レビュー観点

- auto が loopback の http/https URL にだけ適用され、always と off の判定が意図どおりか。
- HEAD 非対応サーバーへの GET フォールバックと、タイムアウト時に Electron を起動しない挙動が妥当か。
- external mode の初回起動と再起動の両方で待機設定が正しく引き回されているか。

## 関連リンク

- なし